### PR TITLE
style:  versão light e dark nas variáveis no root

### DIFF
--- a/styles/global.js
+++ b/styles/global.js
@@ -44,7 +44,7 @@ export default createGlobalStyle`
 
         //OUTLINE   NEUTRALS
             --outline-neutrals-primary: light-dark( #808080, #808080);
-            --outline-neutrals-secondary: light-dark( #666666), #999999;
+            --outline-neutrals-secondary: light-dark( #666666, #999999);
         
         // STATE LAYERS BRAND
             --state-layers-brand-008: #9638FF14;


### PR DESCRIPTION
Atualizei as cores conforme estava no design system, mas acho que vai ter que mudar mais alguma coisa para ficar bom, porque olha como ficou o site:
navegador dark:
![image](https://github.com/user-attachments/assets/225fb53c-defb-439a-be2d-2c7d3d620dea)
navegador light:
![image](https://github.com/user-attachments/assets/1bdcf09b-4b12-407c-8fe6-366db7f2e165)
