### PR TITLE
Feat/home-buttons-345

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -196,7 +196,7 @@ const Home = () => {
                                     <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
                                 </div>
                                 <Button onClick={handleShowAuthModal} disabled={disableAuth}>
-                                    {disableAuth ? 'Cadastros em breve...' : 'Cadastrar-se'}
+                                    {disableAuth ? 'Cadastros em breve...' : 'Cadastre-se'}
                                 </Button>
                             </>
                             :

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,6 +40,14 @@ const supporters = [
     // ].sort((a, b) => a.name > b.name ? 1 : -1);
 ];
 
+const LocationButton = styled(SecondaryButton)`
+    /* estilo especifico apenas para o segundo "Saiba Mais" na Home */
+    width: 100%;
+
+    @media (min-width: 560px) {
+        width: auto;
+    }
+`;
 
 const Home = () => {
 
@@ -437,7 +445,7 @@ const Home = () => {
                         </div>
 
                         <div className='map-btn'>
-                            <SecondaryButton onClick={handleShowMapModal}>Saiba mais</SecondaryButton>
+                            <LocationButton onClick={handleShowMapModal}>Saiba mais</LocationButton>
                         </div>
 
                         {showMapModal &&

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -8,7 +8,7 @@ const Button = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%;
+    width: auto;
     height: 2.75rem;
     padding: var(--padding);
     gap: 0.5rem;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -9,10 +9,11 @@ const Button = styled.button`
     align-items: center;
     justify-content: center;
     width: 100%;
-    height: 3rem;
+    height: 2.75rem;
     padding: var(--padding);
     gap: 0.5rem;
-    border-radius: 0;
+    border-radius: 0.75rem;
+    overflow: hidden; // para que a animacao de hover n vaze da borda arrendondada
     border: var(--brand-primary);
     background-color: var(--background);
     transition: var(--transition-duration);
@@ -45,6 +46,10 @@ const Button = styled.button`
         outline: 2px solid var(--brand-primary);
         outline-offset: 2px;
     }
+
+    @media (min-width: 560px) {
+    height: 3rem;
+} 
 `
 
 export default Button;

--- a/src/components/SecondaryButton.js
+++ b/src/components/SecondaryButton.js
@@ -10,10 +10,10 @@ const SecondaryButton = styled.button`
     align-items: center;
     justify-content: center;
     width: 100%;
-    height: 3rem;
+    height: 2.75rem;
     padding: var(--padding);
     gap: 0.5rem;
-    border-radius: 0;
+    border-radius: 0.75rem;
     border: 2px solid var(--background-neutrals-inverse);
     background-color: transparent;
     transition: var(--transition-duration);
@@ -49,6 +49,10 @@ const SecondaryButton = styled.button`
         outline: 2px solid var(--background-neutrals-inverse);
         outline-offset: 2px;
     }
+
+    @media (min-width: 560px) {
+        height: 3rem;
+        }
 `
 
 export default SecondaryButton;

--- a/src/components/SecondaryButton.js
+++ b/src/components/SecondaryButton.js
@@ -9,7 +9,7 @@ const SecondaryButton = styled.button`
     color: var(--content-neutrals-primary);
     align-items: center;
     justify-content: center;
-    width: 100%;
+    width: auto; 
     height: 2.75rem;
     padding: var(--padding);
     gap: 0.5rem;

--- a/src/components/YoutubeWatchNow.js
+++ b/src/components/YoutubeWatchNow.js
@@ -34,7 +34,6 @@ const YoutubeWatchNowWrapper = styled.div`
 	display: flex;
     flex-direction: row;
 	align-items: center;
-	/* MOBILE FIRST */
 	width: 21.5rem;
 	height: 5rem;
     z-index: 2;
@@ -133,7 +132,6 @@ const YoutubeWatchNowWrapper = styled.div`
 		}
 	}
 
-	/* DESKTOP */
     @media (min-width:560px) {
 		width: 24.75rem;
 		height: 5rem;

--- a/src/components/YoutubeWatchNow.js
+++ b/src/components/YoutubeWatchNow.js
@@ -34,7 +34,8 @@ const YoutubeWatchNowWrapper = styled.div`
 	display: flex;
     flex-direction: row;
 	align-items: center;
-	width: 21rem;
+	/* MOBILE FIRST */
+	width: 21.5rem;
 	height: 5rem;
     z-index: 2;
 
@@ -86,7 +87,10 @@ const YoutubeWatchNowWrapper = styled.div`
     	flex-direction: row;
 		justify-content: space-between;
 		align-items: center;
-		padding: 0.75rem 1.5rem 0.75rem 1rem;
+		padding: 0.75rem 1rem;
+		border-radius: 0.75rem;
+		gap: 1rem;
+		overflow: hidden; // para que a animacao de hover n vaze da borda arrendondada
 		transition: 0.15s all ease-in-out;
         border: 0;
         background-color: var(--background-neutrals-inverse);
@@ -129,8 +133,9 @@ const YoutubeWatchNowWrapper = styled.div`
 		}
 	}
 
+	/* DESKTOP */
     @media (min-width:560px) {
-		width: 24rem;
+		width: 24.75rem;
 		height: 5rem;
 
 		.text {


### PR DESCRIPTION
## O que foi feito
Atualizar o estilo visual dos botões presentes na página `Home` (Botão Principal, Botão Secundário e Botão do YouTube) para que fiquem idênticos ao novo design do Figma, adotando formatos mais arredondados.

Closes #345

### Alterações Realizadas
* **`YoutubeWatchNow.js`:** Adicionado `border-radius` para o formato de pílula, ajustadas as larguras (`width`) e `padding` para as versões Mobile e Desktop, e adicionado `overflow: hidden` para evitar o vazamento do background durante a animação de hover (algo que também foi adicionado no button.js e no SecondaryButton.js).
* **`button.js` (Botão Genérico):** Remoção das bordas retas antigas, aplicação do novo `border-radius` e implementação de altura (`height`).
* **`SecondaryButton.js`:** Atualização de espaçamentos e bordas arredondadas seguindo o mesmo padrão do botão primário.
* **`index.js` (Home):** Alterando o texto do botão principal de "Cadastrar-se" para "Cadastre-se".
* **Unidades Relativas:** Todas as medidas coletadas em pixels no Figma foram convertidas para `rem`.

### Testes e Validação
- Testado visualmente no navegador em resolução Desktop.
- Responsividade validada via DevTools.

#### Home com os botões atualizados:

<img width="1919" height="907" alt="image" src="https://github.com/user-attachments/assets/672ed229-6349-453c-82b2-e740822a6e83" />

<img width="1911" height="643" alt="image" src="https://github.com/user-attachments/assets/fc29c55e-81e8-4e71-9b76-09282355fa3a" />

