### PR TITLE
style: adiciona secao de motivacao e ajusta responsividade

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "webpack": "^5.93.0"
   },
   "devDependencies": {
-    "eslint-config-next": "^15.4.6"
+    "@types/react": "19.2.14",
+    "eslint-config-next": "^15.4.6",
+    "typescript": "6.0.3"
   }
 }

--- a/pages/partnerships.js
+++ b/pages/partnerships.js
@@ -11,6 +11,7 @@ import logoInstagram from '../public/images/partnerships/icons/logo_instagram.sv
 import logoLinkedin from '../public/images/partnerships/icons/logo_linkedin.svg';
 import logoInPerson from '../public/images/partnerships/icons/logo_inPerson.svg';
 import CountUp from 'react-countup';
+import imgMotivation from '../public/images/partnerships/photos/motivation.png';
 
 // components
 import Button from '../src/components/Button';
@@ -49,6 +50,29 @@ const partnerships = () => {
 
             {/* Seção que explica o porquê ser um parceiro da SSI */}
             <MotivationSection>
+
+                <div className='motivationSection'>
+                    <div className='motivationSectionImages'>
+                        <Image
+                            src={imgMotivation}
+                            alt="Imagem de pessoas em um evento"
+                            width={304}
+                            height={252}
+                        />
+                    </div>
+
+                    <div className='motivationSectionText'>
+
+                        <h2>Por que <strong>ser um parceiro</strong> do evento?</h2>
+                        <p>Colaborar com a Semana de SI te garante <strong>contato direto</strong> com centenas de estudantes da <strong>Universidade de São Paulo</strong> e de outras faculdades, compondo um público engajado e altamente qualificado.</p>
+                
+                        <h3>Perfil qualificado</h3>
+                        <p>O público possui forte base em <strong>tecnologia, negócios e gestão.</strong> Além disso, há forte estímulo ao desenvolvimento de <strong>projetos práticos</strong> pela própria graduação e por meio de atividades de extensão. Se inserir no ecossistema universitário te garante como protagonista na formação dos novos profissionais.</p>
+
+                        <h3>Interesses</h3>
+                        <p>No curso de Sistemas de Informação, <strong>89,7% dos estudantes</strong> demonstram interesse em <strong>iniciar um estágio em 2026.</strong> De um total de 804 graduandos, essa parcela possui interesse em variadas áreas do mercado de tecnologia.</p>
+                    </div>
+                </div>
 
             </MotivationSection>
 
@@ -329,6 +353,101 @@ const LandingSection = styled.section`
 `
 
 const MotivationSection = styled.section`
+
+    .motivationSection {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .motivationSectionImages {
+        padding: 2.25em 1.15em; 
+    }
+
+    .motivationSectionText {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75em;
+        margin-bottom: 1.25em;
+        h2 {
+            font-size: 1.25rem;
+            line-height: 1.5rem;
+            font-style: normal;
+            font-weight: 400;
+            font-family: 'AT Aero';
+            strong{
+                background: linear-gradient(90deg, #4A148C 0%, #310C61 100%);
+                padding: 1px 4px; 
+            }
+        }
+        h3 {
+            font-size: 1rem;
+            line-height: 1.5rem;
+            font-weight: 400;
+        }
+
+        p{
+            font-size: 0.875rem;
+            line-height: 1.5rem;
+            font-weight: 400;
+        }
+    }
+
+    @media (min-width: 800px) {
+        .motivationSection {
+           
+            gap: 0.75em;
+
+            .motivationSectionImages {
+                img{
+                    width: 450px;
+                    height: 300px;
+                }
+            }
+
+            .motivationSectionText {
+
+                h2{
+                    font-size: 2.5rem;
+                    line-height: 3.3rem;
+                }
+                h3{
+                    font-size: 1.5rem;
+                }
+                p{
+                    font-size: 1.125rem;
+                }
+            }
+        }
+    }
+
+    @media (min-width: 1200px) {
+        .motivationSection {
+            flex-direction: row;
+            align-items: center;
+            display: flex;
+
+            .motivationSectionImages {
+                img{
+                    width: 609px;
+                    height: 504px;
+                }
+            }
+
+            .motivationSectionText {
+                h2{
+                    font-size: 2.5rem;
+                    line-height: 3.3rem;
+                }
+                h3{
+                    font-size: 1.5rem;
+                }
+                p{
+                    font-size: 1.125rem;
+                }
+            }
+        }
+    }
     
 `
 

--- a/pages/partnerships.js
+++ b/pages/partnerships.js
@@ -50,7 +50,6 @@ const partnerships = () => {
 
             {/* Seção que explica o porquê ser um parceiro da SSI */}
             <MotivationSection>
-
                 <div className='motivationSection'>
                     <div className='motivationSectionImages'>
                         <Image
@@ -60,20 +59,21 @@ const partnerships = () => {
                             height={252}
                         />
                     </div>
-
                     <div className='motivationSectionText'>
-
-                        <h2>Por que <strong>ser um parceiro</strong> do evento?</h2>
-                        <p>Colaborar com a Semana de SI te garante <strong>contato direto</strong> com centenas de estudantes da <strong>Universidade de São Paulo</strong> e de outras faculdades, compondo um público engajado e altamente qualificado.</p>
-                
-                        <h3>Perfil qualificado</h3>
-                        <p>O público possui forte base em <strong>tecnologia, negócios e gestão.</strong> Além disso, há forte estímulo ao desenvolvimento de <strong>projetos práticos</strong> pela própria graduação e por meio de atividades de extensão. Se inserir no ecossistema universitário te garante como protagonista na formação dos novos profissionais.</p>
-
-                        <h3>Interesses</h3>
-                        <p>No curso de Sistemas de Informação, <strong>89,7% dos estudantes</strong> demonstram interesse em <strong>iniciar um estágio em 2026.</strong> De um total de 804 graduandos, essa parcela possui interesse em variadas áreas do mercado de tecnologia.</p>
+                        <div>
+                            <h4>Por que <strong>ser um parceiro</strong> <br/> do evento?</h4>
+                            <p>Colaborar com a Semana de SI te garante <strong>contato direto</strong> com centenas de estudantes da <strong>Universidade de São Paulo</strong> e de outras faculdades, compondo um público engajado e altamente qualificado.</p>
+                        </div>
+                        <div>
+                            <h6>Perfil qualificado</h6>
+                            <p>O público possui forte base em <strong>tecnologia, negócios e gestão.</strong> Além disso, há forte estímulo ao desenvolvimento de <strong>projetos práticos</strong> pela própria graduação e por meio de atividades de extensão. Se inserir no ecossistema universitário te garante como protagonista na formação dos novos profissionais.</p>
+                        </div>
+                        <div>
+                            <h6>Interesses</h6>
+                            <p>No curso de Sistemas de Informação, <strong>89,7% dos estudantes</strong> demonstram interesse em <strong>iniciar um estágio em 2026.</strong> De um total de 804 graduandos, essa parcela possui interesse em variadas áreas do mercado de tecnologia.</p>
+                        </div>
                     </div>
                 </div>
-
             </MotivationSection>
 
             {/* Seção onde a logo de todos os parcerios rodam em um carrossel */}
@@ -353,102 +353,93 @@ const LandingSection = styled.section`
 `
 
 const MotivationSection = styled.section`
+    padding: 2.25rem 1rem;
 
     .motivationSection {
         display: flex;
         flex-direction: column;
+        justify-content: center;
         align-items: center;
+        gap: 2.25rem;
     }
 
     .motivationSectionImages {
-        padding: 2.25em 1.15em; 
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+        img {
+            width: 100%;
+            max-width: 610px;
+            height: auto;
+        }
     }
 
     .motivationSectionText {
         display: flex;
         flex-direction: column;
-        gap: 0.75em;
-        margin-bottom: 1.25em;
-        h2 {
-            font-size: 1.25rem;
-            line-height: 1.5rem;
-            font-style: normal;
+        gap: 0.75rem;
+        
+        div {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem
+        }
+        
+        h4 {
             font-weight: 400;
-            font-family: 'AT Aero';
             strong{
                 background: linear-gradient(90deg, #4A148C 0%, #310C61 100%);
                 padding: 1px 4px; 
             }
         }
-        h3 {
-            font-size: 1rem;
-            line-height: 1.5rem;
+        
+        h6 {
             font-weight: 400;
         }
 
         p{
-            font-size: 0.875rem;
-            line-height: 1.5rem;
             font-weight: 400;
         }
     }
 
-    @media (min-width: 800px) {
-        .motivationSection {
-           
-            gap: 0.75em;
+    @media (min-width: 800px) { 
+        gap: 0.75rem;
 
-            .motivationSectionImages {
-                img{
-                    width: 450px;
-                    height: 300px;
-                }
+        .motivationSectionText {
+            padding: 0;
+            gap: 1.5rem;    
+
+            div {
+                gap: 1rem;
             }
 
-            .motivationSectionText {
-
-                h2{
-                    font-size: 2.5rem;
-                    line-height: 3.3rem;
-                }
-                h3{
-                    font-size: 1.5rem;
-                }
-                p{
-                    font-size: 1.125rem;
-                }
+            h4{
+                font-size: 2.5rem;
+                line-height: 3.3rem;
+            }
+            h6{
+                font-size: 1.5rem;
+            }
+            p{
+                font-size: 1.125rem;
             }
         }
     }
 
-    @media (min-width: 1200px) {
+    @media (min-width: 1180px) {
+        padding: 4.5rem 1rem;
+
         .motivationSection {
             flex-direction: row;
-            align-items: center;
-            display: flex;
+            gap: 3rem;
 
-            .motivationSectionImages {
-                img{
-                    width: 609px;
-                    height: 504px;
-                }
-            }
-
-            .motivationSectionText {
-                h2{
-                    font-size: 2.5rem;
-                    line-height: 3.3rem;
-                }
-                h3{
-                    font-size: 1.5rem;
-                }
-                p{
-                    font-size: 1.125rem;
-                }
+            img{
+                width: 610px;
+                max-width: auto;
             }
         }
     }
-    
 `
 
 const SponsorsSection = styled.section`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,6 +811,13 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/react@19.2.14":
+  version "19.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
+  integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
+  dependencies:
+    csstype "^3.2.2"
+
 "@types/stylis@4.2.5":
   version "4.2.5"
   resolved "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz"
@@ -1486,6 +1493,11 @@ csstype@3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
@@ -3357,6 +3369,11 @@ typed-array-length@^1.0.7:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
+
+typescript@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Adiciona a seção motivation section de maneira responsiva, além de media queries para tablet e desktop

Mobile:

<img width="442" height="617" alt="image" src="https://github.com/user-attachments/assets/01334c27-48d8-4d4c-86fe-201dc19df341" />

<img width="445" height="778" alt="image" src="https://github.com/user-attachments/assets/b6b8d47b-4a12-4ca4-9d52-927c666a0028" />

Tablet:

<img width="518" height="503" alt="image" src="https://github.com/user-attachments/assets/d84b3d50-9190-48ba-8761-5f6811709ec3" />

Desktop:

<img width="910" height="362" alt="image" src="https://github.com/user-attachments/assets/fd9aaf5e-46f7-4041-9eeb-70e9c31b61ed" />
