### PR TITLE
fix: adicionado padding para não sobrepor o botão do canal à contagem regressiva

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -176,7 +176,7 @@ const Home = () => {
                         {disableAuth || !user ?
                             <>
                                 <div className='landing-text'>
-                                    <h1>Semana de Sistemas de Informação 2025</h1>
+                                    <h1>Semana de Sistemas de Informação 2026</h1>
                                     <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
                                 </div>
                                 <Button onClick={handleShowAuthModal} disabled={disableAuth}>
@@ -186,7 +186,7 @@ const Home = () => {
                             :
                             <>
                                 <div className='landing-text'>
-                                    <h1>Semana de Sistemas de Informação 2025</h1>
+                                    <h1>Semana de Sistemas de Informação 2026</h1>
                                     <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
                                     <p className='greetings-text'>Olá, <span>{user.name ? `${user.name.split(' ')[0]}` : ''}</span>!</p>
                                 </div>
@@ -609,10 +609,11 @@ const LandingSection = styled.section`
     }
 
     @media (min-width:1100px) {
-        //height: 44rem;
+        // height: 40rem;
 
         .landing-container {
-            height: calc(100vh - 14rem);
+            // height: calc(100vh - 14rem);
+            padding: 2rem 0 4rem 0;
             flex-direction: row;
             justify-content: space-between;
 


### PR DESCRIPTION
Há um problema na Home na qual o botão 'Confira nosso canal' está sobrepondo e tampando parte da contagem regressiva da data do evento.

Print do problema:
<img width="1835" height="875" alt="Screenshot_1" src="https://github.com/user-attachments/assets/17814fc6-1999-49e6-a136-c0665042c8d7" />

Print de como ficou:
<img width="1836" height="878" alt="Screenshot_2" src="https://github.com/user-attachments/assets/3351a2b7-4b3c-4884-bf61-1f1b68c4b643" />

Apenas adicionei padding top e padding bottom ao .landing-container, dando mais espaço para o botão. Removi (comentei) o height do mesmo, pois, estava fixa e não seguia a responsividade das outras divs principais (Mas só é notável quando diminui bastante o zoom).

Já havia um height para o section que também resolvia isso, mas estava comentado. Portanto não tenho certeza se alguém já estava para ver isso. Entretanto, achei o padding melhor do que definir um height.

Texto 2025 para 2026.