### PR TITLE
Refactor/385 remover hardcode index

### DIFF
--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -9,7 +9,7 @@ export const eventDetails = {
     monthYear: "Ago 2026"
   },
 
-  countdownDate: "2026-08-24T00:00:00",
+  countdownDate: "2026-08-24T09:40:00-03:00",
 
   logic: {
     // so nao esquecer que no Date do JS o mes começa em 0, logo 7 = agosto

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -13,8 +13,8 @@ export const eventDetails = {
 
   logic: {
     // so nao esquecer que no Date do JS o mes começa em 0, logo 7 = agosto
-    startJS: new Date(2026, 7, 24), 
-    endJS: new Date(2026, 7, 28),
+    startJS: (2026, 7, 24), 
+    endJS: (2026, 7, 28),
     fallbackString: "2026-08-24",
     filterEventDays: [
       "24 Ago - Segunda-feira", 

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -1,5 +1,6 @@
 export const eventDetails = {
   year: "2026",
+  edition: "17",
   dateText: "24 a 28 de agosto", 
   startDate: "2026-08-24T00:09:30-03:00",
   endDate: "2026-08-28T23:59:59-03:00", 

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -2,15 +2,14 @@ export const eventDetails = {
   year: "2026",
   edition: "17",
   dateText: "24 a 28 de agosto", 
-  startDate: "2026-08-24T00:09:30-03:00",
+  // startDate: "2026-08-24T09:40:00-03:00",
+  startDate: "2026-08-24T09:40:00-03:00",
   endDate: "2026-08-28T23:59:59-03:00", 
   
   hero: {
     shortDate: "24-28",
     monthYear: "Ago 2026"
   },
-
-  countdownDate: "2026-08-24T09:40:00-03:00",
 
   logic: {
     // so nao esquecer que no Date do JS o mes começa em 0, logo 7 = agosto
@@ -29,9 +28,9 @@ export const eventDetails = {
   },
 
   stats: {
-    draws: 25,     // qnt de sorteios
-    speakers: 40,  // qnt de palestrantes
-    hours: 45      // qnt de horas de atividade
+    draws: 25,     // quatidade de sorteios
+    speakers: 40,  // quatidade de palestrantes
+    hours: 45      // quatidade de horas de atividade
   },
 
    links: {

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -4,6 +4,30 @@ export const eventDetails = {
   year: "2026",
   dateText: "24 a 28 de agosto", 
   startDate: "2026-08-24T00:09:30-03:00",
-  endDate: "2026-08-28T23:59:59-03:00" // TODO: verificar se o horário de término é realmente às 23:59:59
-  // Adicione outras informações relevantes do evento aqui
-};
+  endDate: "2026-08-28T23:59:59-03:00", 
+  
+  hero: {
+    shortDate: "24-28",
+    monthYear: "Ago 2026"
+  },
+
+  countdownDate: "2026-08-24T00:00:00",
+
+  logic: {
+    // so nao esquecer que no Date do JS o mes começa em 0, logo 7 = agosto
+    startJS: new Date(2026, 7, 24), 
+    endJS: new Date(2026, 7, 28),
+    fallbackString: "2026-08-24",
+    filterEventDays: ["24", "25", "26", "27", "28"]
+  },
+
+  stats: {
+    draws: 25,     // qnt de sorteios
+    speakers: 40,  // qnt de palestrantes
+    hours: 45      // qnt de horas de atividade
+  },
+
+  /* links: {
+    coRegistration: "https://forms.gle/cole-o-link-aqui" 
+  } */ 
+}; 

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -13,8 +13,10 @@ export const eventDetails = {
 
   logic: {
     // so nao esquecer que no Date do JS o mes começa em 0, logo 7 = agosto
-    startJS: (2026, 7, 24), 
-    endJS: (2026, 7, 28),
+    //startJS: (2026, 7, 24), 
+    //endJS: (2026, 7, 28),
+    startJS: new Date(2026, 7, 24),
+    endJS: new Date(2026, 7, 28),
     fallbackString: "2026-08-24",
     filterEventDays: [
       "24 Ago - Segunda-feira", 

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -18,7 +18,13 @@ export const eventDetails = {
     startJS: new Date(2026, 7, 24), 
     endJS: new Date(2026, 7, 28),
     fallbackString: "2026-08-24",
-    filterEventDays: ["24", "25", "26", "27", "28"]
+    filterEventDays: [
+      "24 Ago - Segunda-feira", 
+      "25 Ago - Terça-feira", 
+      "26 Ago - Quarta-feira", 
+      "27 Ago - Quinta-feira", 
+      "28 Ago - Sexta-feira"
+    ]
   },
 
   stats: {

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -1,6 +1,4 @@
 export const eventDetails = {
-  name: "SSI",
-  fullName: "Semana de Sistemas de Informação",
   year: "2026",
   dateText: "24 a 28 de agosto", 
   startDate: "2026-08-24T00:09:30-03:00",
@@ -33,7 +31,7 @@ export const eventDetails = {
     hours: 45      // qnt de horas de atividade
   },
 
-  /* links: {
-    coRegistration: "https://forms.gle/cole-o-link-aqui" 
-  } */ 
+   links: {
+    coRegistration: "https://forms.gle/cole-o-link-aqui-meu-fan-de-jojo" 
+  } 
 }; 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "webpack": "^5.93.0"
   },
   "devDependencies": {
-    "@types/react": "19.2.14",
+    "@types/react": "19.2.15",
     "eslint-config-next": "^15.4.6",
     "typescript": "6.0.3"
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -173,6 +173,8 @@ const Home = () => {
         }
     }, [showMapModal]); 
 
+    // Verifica se a data atual é anterior ao início do evento para exibir a contagem regressiva na LandingSection
+    const isCronologicallyBeforeEvent = current < eventDetails.logic.startJS;
 
     return (
         <>
@@ -229,7 +231,7 @@ const Home = () => {
                                 <h6>Online e <br /> Presencial</h6>
                             </div>
                         </div>
-                        <CountdownSection targetDate={eventDetails.countdownDate}/>   
+                        {isCronologicallyBeforeEvent && <CountdownSection targetDate={eventDetails.startDate} />}
                     </div>
                 </div>
             </LandingSection>

--- a/pages/index.js
+++ b/pages/index.js
@@ -86,8 +86,13 @@ const Home = () => {
         getSchedule()
     }, [])
 
-    const firstEventDay = eventDetails.logic.startJS;
-    const lastEventDay = eventDetails.logic.endJS;
+    
+    //const firstEventDay = eventDetails.logic.startJS;
+    //const lastEventDay = eventDetails.logic.endJS;
+    const firstEventDay = new Date(eventDetails.logic.startJS);
+    const lastEventDay = new Date(eventDetails.logic.endJS);
+    //const firstEventDay = new Date(2025, 7, 18);
+    //const lastEventDay = new Date(2025, 7, 22);
     lastEventDay.setHours(23, 59, 59, 999);  // Define para o final do dia (23:59:59.999)
 
     const current = new Date();

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,7 +7,6 @@ import useAuth from '../hooks/useAuth';
 import Meta from '../src/infra/Meta';
 import '../utils/slugify';
 import filterTalks from '../utils/filterTalks';
-import { EVENT_DETAILS } from '../data/eventDetails';
 import { eventDetails } from '../data/eventDetails';
 
 // importe Image do next

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,7 @@ import Meta from '../src/infra/Meta';
 import '../utils/slugify';
 import filterTalks from '../utils/filterTalks';
 import { EVENT_DETAILS } from '../data/eventDetails';
+import { eventDetails } from '../data/eventDetails';
 
 // importe Image do next
 import Image from 'next/image'
@@ -22,6 +23,7 @@ import SecondaryButton from '../src/components/SecondaryButton';
 import YoutubeWatchNow from '../src/components/YoutubeWatchNow';
 import saphira from '../services/saphira';
 import CountdownSection from '../src/components/CountdownSection';
+
 
 const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY
 
@@ -84,8 +86,8 @@ const Home = () => {
         getSchedule()
     }, [])
 
-    const firstEventDay = new Date(2025, 7, 18);
-    const lastEventDay = new Date(2025, 7, 22);
+    const firstEventDay = eventDetails.logic.startJS;
+    const lastEventDay = eventDetails.logic.endJS;
     lastEventDay.setHours(23, 59, 59, 999);  // Define para o final do dia (23:59:59.999)
 
     const current = new Date();
@@ -98,7 +100,7 @@ const Home = () => {
 
     // Dia no formato yyyy-mm-dd para o ScheduleShift
     const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
-    const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : '2025-08-18';
+    const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
 
     const filterEventDays = ["18 Ago - Segunda-feira", "19 Ago - Terça-feira", "20 Ago - Quarta-feira", "21 Ago - Quinta-feira", "22 Ago - Sexta-feira"];
     const filterEventDaysId = scheduleDay - firstEventDay.getDate();

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,7 +7,6 @@ import useAuth from '../hooks/useAuth';
 import Meta from '../src/infra/Meta';
 import '../utils/slugify';
 import filterTalks from '../utils/filterTalks';
-import { EVENT_DETAILS } from '../data/eventDetails';
 import { eventDetails } from '../data/eventDetails';
 
 // importe Image do next
@@ -88,8 +87,8 @@ const Home = () => {
 
     const firstEventDay = new Date(2025, 7, 18);
     const lastEventDay = new Date(2025, 7, 22);
-    //const firstEventDay = new Date(2026, 7, 24);
-    //const lastEventDay = new Date(2026, 7, 28);
+    // const firstEventDay = new Date(2026, 7, 24);
+    // const lastEventDay = new Date(2026, 7, 28);
     //const firstEventDay = eventDetails.logic.startJS;
     //const lastEventDay = eventDetails.logic.endJS;
     lastEventDay.setHours(23, 59, 59, 999);  // Define para o final do dia (23:59:59.999)
@@ -104,9 +103,9 @@ const Home = () => {
 
     // Dia no formato yyyy-mm-dd para o ScheduleShift
     const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
-    const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
-    //const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : '2025-08-18';
 
+    // Se a data atual estiver entre o primeiro e o último dia do evento, use a data atual; caso contrário, use a data do primeiro dia do evento (fallback)
+    const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
 
     const filterEventDays = eventDetails.logic.filterEventDays;
     const filterEventDaysId = scheduleDay - firstEventDay.getDate();
@@ -172,7 +171,7 @@ const Home = () => {
             document.body.style.overflow = 'unset';
             document.body.style.paddingRight = 'unset';
         }
-    }, [showMapModal]);
+    }, [showMapModal]); 
 
 
     return (
@@ -224,7 +223,7 @@ const Home = () => {
 
                             <div>
                                 <picture>
-                                    <source srcset="/images/logos/usp-dark.svg" media="(prefers-color-scheme: dark)" />
+                                    <source srcSet="/images/logos/usp-dark.svg" media="(prefers-color-scheme: dark)" />
                                     <img src="/images/logos/usp-light.svg" alt="Logo USP" width={33} height={33} />
                                 </picture>
                                 <h6>Online e <br /> Presencial</h6>

--- a/pages/index.js
+++ b/pages/index.js
@@ -86,13 +86,12 @@ const Home = () => {
         getSchedule()
     }, [])
 
-    
+    const firstEventDay = new Date(2025, 7, 18);
+    const lastEventDay = new Date(2025, 7, 22);
+    //const firstEventDay = new Date(2026, 7, 24);
+    //const lastEventDay = new Date(2026, 7, 28);
     //const firstEventDay = eventDetails.logic.startJS;
     //const lastEventDay = eventDetails.logic.endJS;
-    const firstEventDay = new Date(eventDetails.logic.startJS);
-    const lastEventDay = new Date(eventDetails.logic.endJS);
-    //const firstEventDay = new Date(2025, 7, 18);
-    //const lastEventDay = new Date(2025, 7, 22);
     lastEventDay.setHours(23, 59, 59, 999);  // Define para o final do dia (23:59:59.999)
 
     const current = new Date();
@@ -106,6 +105,8 @@ const Home = () => {
     // Dia no formato yyyy-mm-dd para o ScheduleShift
     const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
     const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
+    //const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : '2025-08-18';
+
 
     const filterEventDays = eventDetails.logic.filterEventDays;
     const filterEventDaysId = scheduleDay - firstEventDay.getDate();
@@ -217,8 +218,8 @@ const Home = () => {
                     <div className="dates">
                         <div className="dateWrapper">
                             <div>
-                                <h1>24-28</h1>
-                                <h2>Ago 2026</h2>
+                                <h1>{eventDetails.hero.shortDate}</h1>
+                                <h2>{eventDetails.hero.monthYear}</h2>
                             </div>
 
                             <div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import useAuth from '../hooks/useAuth';
 import Meta from '../src/infra/Meta';
 import '../utils/slugify';
 import filterTalks from '../utils/filterTalks';
+import { EVENT_DETAILS } from '../data/eventDetails';
 import { eventDetails } from '../data/eventDetails';
 
 // importe Image do next

--- a/pages/index.js
+++ b/pages/index.js
@@ -102,7 +102,7 @@ const Home = () => {
     const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
     const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
 
-    const filterEventDays = ["18 Ago - Segunda-feira", "19 Ago - Terça-feira", "20 Ago - Quarta-feira", "21 Ago - Quinta-feira", "22 Ago - Sexta-feira"];
+    const filterEventDays = eventDetails.logic.filterEventDays;
     const filterEventDaysId = scheduleDay - firstEventDay.getDate();
 
     // Transforma 00:00 em minutos depois da meia noite para fazer calculos
@@ -179,8 +179,10 @@ const Home = () => {
                         {disableAuth || !user ?
                             <>
                                 <div className='landing-text'>
-                                    <h1>Semana de Sistemas de Informação 2026</h1>
-                                    <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
+                                    <h1>Semana de Sistemas de Informação {eventDetails.year}</h1>
+                                     <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, 
+                                        Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. 
+                                        Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
                                 </div>
                                 <Button onClick={handleShowAuthModal} disabled={disableAuth}>
                                     {disableAuth ? 'Cadastros em breve...' : 'Cadastre-se'}
@@ -189,8 +191,10 @@ const Home = () => {
                             :
                             <>
                                 <div className='landing-text'>
-                                    <h1>Semana de Sistemas de Informação 2026</h1>
-                                    <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
+                                    <h1>Semana de Sistemas de Informação {eventDetails.year}</h1>
+                                     <p>Participe da Semana de Sistemas de Informação! Mais de 40 palestrantes, temas como Inteligência Artificial, 
+                                        Ciência de Dados, Diversidade em TI e Desenvolvimento de Jogos, com especialistas de diversas empresas. 
+                                        Não perca essa chance de se conectar, aprender e inovar com as mentes que estão moldando o futuro da tecnologia!</p>
                                     <p className='greetings-text'>Olá, <span>{user.name ? `${user.name.split(' ')[0]}` : ''}</span>!</p>
                                 </div>
                             </>
@@ -220,7 +224,7 @@ const Home = () => {
                                 <h6>Online e <br /> Presencial</h6>
                             </div>
                         </div>
-                        <CountdownSection targetDate={"Aug 24, 2026 09:40:00"}/>   
+                        <CountdownSection targetDate={eventDetails.countdownDate}/>   
                     </div>
                 </div>
             </LandingSection>
@@ -238,7 +242,7 @@ const Home = () => {
 
                         <p>Junte-se à <span>Comissão Organizadora</span> da SSI 2026 e ajude a criar o melhor evento acadêmico de Sistemas de Informação!</p>
 
-                        <a href='https://forms.gle/EnTh6tMkMag4zXoj8' target="_blank">
+                        <a href={eventDetails.links.coRegistration} target="_blank">
                             <Button>Inscrever-se</Button>
                         </a>
                     </div>
@@ -262,7 +266,7 @@ const Home = () => {
                         <div className='about-cards'>
                             <CountUp
                                 start={0}
-                                end={40}
+                                end={eventDetails.stats.speakers}
                                 delay={0}
                                 decimals={0}
                                 suffix="+"
@@ -274,7 +278,7 @@ const Home = () => {
                                             <h5 ref={countUpRef}/>
                                             <h5>palestrantes</h5>
                                         </div>
-                                        <p>Junte-se ao evento que contará com mais de 40 palestrantes, trazendo as últimas tendências e insights do mercado!</p>
+                                        <p>Junte-se ao evento que contará com mais de {eventDetails.stats.speakers} palestrantes, trazendo as últimas tendências e insights do mercado!</p>
                                     </div>
                                 )}
                             </CountUp>
@@ -283,7 +287,7 @@ const Home = () => {
                         <div className='about-cards'>
                             <CountUp
                                 start={0}
-                                end={25}
+                                end={eventDetails.stats.draws}
                                 delay={0}
                                 decimals={0}
                                 suffix="+"
@@ -295,7 +299,7 @@ const Home = () => {
                                             <h5 ref={countUpRef} />
                                             <h5>sorteios</h5>
                                         </div>
-                                        <p>Participe do evento de tecnologia e concorra a mais de 25 sorteios exclusivos, repletos de prêmios incríveis!</p>
+                                        <p>Participe do evento de tecnologia e concorra a mais de {eventDetails.stats.draws} sorteios exclusivos, repletos de prêmios incríveis!</p>
                                     </div>
                                 )}
                             </CountUp>
@@ -304,7 +308,7 @@ const Home = () => {
                         <div className='about-cards'>
                             <CountUp
                                 start={0}
-                                end={45}
+                                end={eventDetails.stats.hours}
                                 delay={0}
                                 decimals={0}
                                 suffix="h"
@@ -316,7 +320,7 @@ const Home = () => {
                                             <h5 ref={countUpRef} />
                                             <h5>atividades</h5>
                                         </div>
-                                        <p>Não perca um evento com 45 horas de atividades repletas de conteúdo e inovação para você se atualizar!</p>
+                                        <p>Não perca um evento com {eventDetails.stats.hours} horas de atividades repletas de conteúdo e inovação para você se atualizar!</p>
                                     </div>
                                 )}
                             </CountUp>

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,10 +811,10 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/react@19.2.14":
-  version "19.2.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
-  integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
+"@types/react@19.2.15":
+  version "19.2.15"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.15.tgz#9e2c6a4251a290f5c525c3143caa872fa6e01e0d"
+  integrity sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==
   dependencies:
     csstype "^3.2.2"
 


### PR DESCRIPTION
## O que foi feito?
Este PR resolve a issue #385, eliminando todas as informações estáticas (*hardcoded*) da página Home (`pages/index.js`) e centralizando-as em um arquivo unificado de metadados na pasta `data/eventDetails.js`.

Essa reestruturação garante previsibilidade e facilidade de manutenção para as próximas edições da SSI, permitindo que a equipe mude o ano, as datas, as estatísticas e os links em um único ponto da aplicação.

## Mudanças detalhadas:
* **Criação do arquivo `data/eventDetails.js`:** Concentra dados como o nome do evento, ano corrente, strings de exibição da Hero, limites do cronômetro, estatísticas dos cards e links auxiliares.
* **Componentes Dinâmicos:** * O `<CountdownSection />` agora consome a propriedade `countdownDate` dinamicamente.
  * Os blocos de `<CountUp />` (Sorteios, Palestrantes e Atividades) e seus respectivos parágrafos textuais foram atualizados para herdar os números do arquivo central.
* **Seção de Inscrição da CO:** Ajuste no bloco comentado/oculto para herdar o ano e o link do formulário dinamicamente, prevenindo a publicação acidental de links antigos. (precisa só atualizar o link do formulário no eventDetails.js, coloquei um não existente no momento)

---

## Observação Importante: Lógica de Datas e o Componente `ScheduleSection`

Durante os testes locais de virada de ano para **2026**,  foi identificado um comportamento colateral preexistente no arquivo `pages/index.js` envolvendo o componente `<ScheduleSection>` (responsável por envelopar o bloco de "Próximas Atividades"). O seguinte erro ocorria:

<img width="1280" height="596" alt="image" src="https://github.com/user-attachments/assets/8a96e757-365a-4da2-a91d-99d980bb5818" />

### Teoria/Especulação da causa

* **Por que funcionava com as datas de 2025?** A condicional `{(current <= lastEventDay) && <ScheduleSection>...}` resultava em `false` (já que a data atual é maior que o limite de agosto de 2025). Como o React não tentava renderizar o bloco, o interpretador do JavaScript nunca chegava a ler a tag `<ScheduleSection>`, mascarando o fato de o componente/bloco de código do mesmo estar ausente no escopo atual da branch.

<img width="1558" height="593" alt="image" src="https://github.com/user-attachments/assets/84651ca3-8284-46fd-83c0-ff541dc6c378" />

* **Por que quebrava com as datas de 2026?** Ao atualizar as variáveis para 2026, a condição passa a ser `true`. O React tenta renderizar a seção de programação e estoura um `ReferenceError`.

### Como o código foi mitigado neste PR:
Para entregar a refatoração desta issue sem travar o progresso em problemas de layout/estilo alheios, adotei a seguinte estratégia:
1. Mantive a lógica ativa lendo as datas de **2025** para garantir que o Next.js compile a página normalmente sem quebras (*reference errors*).
2. Deixei a implementação correta de **2026** comentada logo abaixo.

<img width="1296" height="428" alt="image" src="https://github.com/user-attachments/assets/3dc5c214-7f03-432c-abfa-5c026f7b21da" />
