### PR TITLE
Refactor/remover hardcode sobre co

### DIFF
--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -12,7 +12,7 @@ export const eventDetails = {
     monthYear: "Ago 2026"
   },
 
-  lastYearStats: {
+  lastYearStats: { // estatísticas da transmissão no youtube do evento do ano anterior
     viewers: 2,       
     subscribers: 600,
     contentHours: 43  

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -5,12 +5,17 @@ export const eventDetails = {
   dateText: "24 a 28 de agosto", 
   startDate: "2026-08-24T09:40:00-03:00",
   endDate: "2026-08-28T23:59:59-03:00", 
-  
   regulationLink: "https://docs.google.com/document/d/1ROLkjMU-hxvPW5BlVpEm1wnzZN1z32YsQc5u69u1pSk/edit?usp=sharing",
   
   hero: {
     shortDate: "24-28",
     monthYear: "Ago 2026"
+  },
+
+  lastYearStats: {
+    viewers: 2,       
+    subscribers: 600,
+    contentHours: 43  
   },
 
   logic: {

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -1,10 +1,12 @@
 export const eventDetails = {
   year: "2026",
+  lastYear: String(2026 - 1),
   edition: "17",
   dateText: "24 a 28 de agosto", 
-  // startDate: "2026-08-24T09:40:00-03:00",
   startDate: "2026-08-24T09:40:00-03:00",
   endDate: "2026-08-28T23:59:59-03:00", 
+  
+  regulationLink: "https://docs.google.com/document/d/1ROLkjMU-hxvPW5BlVpEm1wnzZN1z32YsQc5u69u1pSk/edit?usp=sharing",
   
   hero: {
     shortDate: "24-28",

--- a/data/socials.js
+++ b/data/socials.js
@@ -2,6 +2,6 @@ export const socials = {
   instagram: "https://www.instagram.com/semanadesi/",
   linkedin: "https://www.linkedin.com/company/semandesi",
   youtube: "https://www.youtube.com/@semanadesi",
-  aftermovieEmbed: "https://www.youtube.com/embed/tHkBBqcpb3I?si=ISLt0jiKNzuyd5g2"
+  aftermovieEmbed: "https://www.youtube.com/embed/tHkBBqcpb3I?si=ISLt0jiKNzuyd5g2" // Link do video do youtube na pagina about.js
   // Adicione outras redes sociais conforme necessário
 };

--- a/data/socials.js
+++ b/data/socials.js
@@ -1,6 +1,7 @@
 export const socials = {
   instagram: "https://www.instagram.com/semanadesi/",
   linkedin: "https://www.linkedin.com/company/semandesi",
-  youtube: "https://www.youtube.com/@semanadesi"
+  youtube: "https://www.youtube.com/@semanadesi",
+  aftermovieEmbed: "https://www.youtube.com/embed/tHkBBqcpb3I?si=ISLt0jiKNzuyd5g2"
   // Adicione outras redes sociais conforme necessário
 };

--- a/pages/about.js
+++ b/pages/about.js
@@ -39,7 +39,7 @@ const About = () => {
                     <div className='text'>
                         <h1>Sobre o Evento</h1>
                         <p>A Semana de Sistemas de Informação é um evento anual organizado por alunas e alunos do curso de Sistemas de Informação da Escola de Artes, Ciências e Humanidades da Universidade de São Paulo (EACH - USP).</p>
-                        <a href='https://docs.google.com/document/d/1ROLkjMU-hxvPW5BlVpEm1wnzZN1z32YsQc5u69u1pSk/edit?usp=sharing' target="_blank">
+                        <a href={eventDetails.regulationLink} target="_blank">
                             <Button>
                                 Conferir regulamento
                                 <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -53,7 +53,7 @@ const About = () => {
                             <source srcSet = {LogoCircularLight} media='(prefers-color-scheme: light)'/>
                             <Image
                                 src={LogoCircularDark}
-                                alt="Gif SSI 2025"
+                                alt={`Gif SSI ${eventDetails.year}`} 
                                 width={500}
                                 height={500}
                                 className='image'
@@ -82,7 +82,7 @@ const About = () => {
                             <div className='bait-sample-description'>
                                 <div className='bait-sample-title'>
                                     <h5>Palestras</h5>
-                                    <p>A Semana de Sistemas de Informação 2025 contará com diversas palestras da área da tecnologia.</p>
+                                    <p>A Semana de Sistemas de Informação {eventDetails.year} contará com diversas palestras da área da tecnologia.</p>
                                 </div>
 
                                 <div className='bait-sample-subtitles'>
@@ -220,7 +220,7 @@ const About = () => {
                     }
 
                     <p className='gifts-cards-obs'>
-                        Teremos distribuição de brindes exclusivos para os participantes da SSI 2025. Basta registrar as suas presenças e verificar a contagem no seu perfil.
+                        Teremos distribuição de brindes exclusivos para os participantes da SSI {eventDetails.year}. Basta registrar as suas presenças e verificar a contagem no seu perfil.
                     </p>
                 </div>
             </GiftsSection>
@@ -229,7 +229,7 @@ const About = () => {
                 <div className='lastyear-container'>
                     <div className='lastyear-text'>
                         <div className='lastyear-title'>
-                            <h3>Veja como foi em 2024</h3>
+                            <h3>Veja como foi em {eventDetails.lastYear}</h3>
                         </div>
                         <h6>
                             Confira o que rolou no evento do ano passado e sinta a energia que tomou conta do nosso público!
@@ -239,7 +239,7 @@ const About = () => {
                     <div className='lastyear-content'>
                         <div className='lastyear-video'>
                             <iframe
-                                src="https://www.youtube.com/embed/tHkBBqcpb3I?si=ISLt0jiKNzuyd5g2"
+                                src={socials.aftermovieEmbed}
                                 title="YouTube video player"
                                 allow="fullscreen">
                             </iframe>
@@ -247,7 +247,7 @@ const About = () => {
                         <EventNumbersBanner>
                             <CountUp
                                 start={0}
-                                end={2}
+                                end={lastYearStats.viewers}
                                 delay={0}
                                 decimals={1}
                                 suffix="k+"
@@ -263,7 +263,7 @@ const About = () => {
 
                             <CountUp
                                 start={0}
-                                end={600}
+                                end={lastYearStats.subscribers}
                                 delay={0}
                                 suffix="+"
                                 enableScrollSpy
@@ -278,7 +278,7 @@ const About = () => {
 
                             <CountUp
                                 start={0}
-                                end={43}
+                                end={lastYearStats.contentHours}
                                 delay={0}
                                 suffix="h"
                                 enableScrollSpy
@@ -292,7 +292,7 @@ const About = () => {
                             </CountUp>
                         </EventNumbersBanner>
 
-                        <a href='https://www.youtube.com/@semanadesi' target='_blank'>
+                        <a href={socials.youtube} target='_blank'>
                             <SecondaryButton $noSvgColorChange>
                                 Acesse nosso canal
                                 <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 56 56" fill="none">

--- a/pages/about.js
+++ b/pages/about.js
@@ -247,7 +247,7 @@ const About = () => {
                         <EventNumbersBanner>
                             <CountUp
                                 start={0}
-                                end={lastYearStats.viewers}
+                                end={eventDetails.lastYearStats.viewers}
                                 delay={0}
                                 decimals={1}
                                 suffix="k+"
@@ -263,7 +263,7 @@ const About = () => {
 
                             <CountUp
                                 start={0}
-                                end={lastYearStats.subscribers}
+                                end={eventDetails.lastYearStats.subscribers}
                                 delay={0}
                                 suffix="+"
                                 enableScrollSpy
@@ -278,7 +278,7 @@ const About = () => {
 
                             <CountUp
                                 start={0}
-                                end={lastYearStats.contentHours}
+                                end={eventDetails.lastYearStats.contentHours}
                                 delay={0}
                                 suffix="h"
                                 enableScrollSpy

--- a/pages/about.js
+++ b/pages/about.js
@@ -6,6 +6,9 @@ import useAuth from '../hooks/useAuth';
 import Meta from '../src/infra/Meta';
 import gifts from '../data/gifts';
 
+import { eventDetails } from '../data/eventDetails';
+import { socials } from '../data/socials';
+
 // components
 import Button from '../src/components/Button';
 import GiftCard from '../src/components/GiftCard';

--- a/pages/co.js
+++ b/pages/co.js
@@ -4,6 +4,8 @@ import styled, { css } from 'styled-components';
 
 import Meta from '../src/infra/Meta';
 
+import { eventDetails } from '../data/eventDetails';
+
 // components
 import DepartmentStamp from '../src/components/DepartmentStamp';
 import MemberCard from '../src/components/MemberCard';
@@ -70,8 +72,8 @@ const CO = () => {
     return (
         <>
             <Meta title='Comissão Organizadora | Semana de Sistemas de Informação' 
-            description='Conheça a comissão organizadora da SSI 2025. Estudantes dedicados à realização de um dos maiores eventos acadêmicos de tecnologia do país.'
-            keywords='comissão SSI, organização do evento, estudantes organizadores, quem organiza a SSI, equipe SSI 2025, comissão sistemas de informação, organização semana tecnologia'
+            description={`Conheça a comissão organizadora da SSI ${eventDetails.year}. Estudantes dedicados à realização de um dos maiores eventos acadêmicos de tecnologia do país.`}
+            keywords={`comissão SSI, organização do evento, estudantes organizadores, quem organiza a SSI, equipe SSI ${eventDetails.year}, comissão sistemas de informação, organização semana tecnologia`}
             />
 
             <COExhibitionSection>

--- a/src/components/DepartmentStamp.js
+++ b/src/components/DepartmentStamp.js
@@ -1,9 +1,9 @@
 import styled, { css } from 'styled-components';
 
-const DepartmentStamp = ( { name, itemColor, $active } ) => {
+const DepartmentStamp = ( { name, $itemColor, $active } ) => {
 
     return (
-        <DepartmentWrapper name={name} itemColor={itemColor} $active={$active}>
+        <DepartmentWrapper name={name} $itemColor={$itemColor} $active={$active}>
             <p>{name}</p>
         </DepartmentWrapper>
     );
@@ -21,24 +21,24 @@ const DepartmentWrapper = styled.div`
     ${props => props.$active === false && css`
         p {
             text-align: center;
-            color: var(--background-neutrals-primary);
+            color: transparent;
             -webkit-text-stroke-width: 1px;
-            -webkit-text-stroke-color: ${props.itemColor};
+            -webkit-text-stroke-color: ${props.$itemColor};
             -webkit-line-clamp: 2;
             font: 400 3rem/3rem 'AT Aero Bold';
         }
 
         p:hover {
-            color: ${props.itemColor};
+            color: ${props.$itemColor};
         }
     `}
 
     ${props => (props.$active || props.$hover) === true && css`
         p {
             text-align: center;
-            color: ${props.itemColor};
+            color: ${props.$itemColor};
             -webkit-text-stroke-width: 1px;
-            -webkit-text-stroke-color: ${props.itemColor};
+            -webkit-text-stroke-color: ${props.$itemColor};
             -webkit-line-clamp: 2;
             font: 400 3rem/3rem 'AT Aero Bold';
         }


### PR DESCRIPTION
## O que foi feito?
Este PR resolve a issue #388, realizando uma limpa completa de dados estáticos (*hardcoded*) nos arquivos das rotas "Sobre" (`pages/about.js`) e "Comissão Organizadora" (`pages/co.js`). 

Todas as menções fixas a anos de edições anteriores, metadados de SEO desatualizados e links externos foram extraídos e acoplados aos nossos arquivos de configuração centralizada (`data/eventDetails.js` e `data/socials.js`).

##  Mudanças detalhadas:

### Página Sobre (`pages/about.js`):
* **Metadados Dinâmicos:** O atributo `alt` da logo circular foi alterado para renderizar o ano corrente dinamicamente utilizando *template literals*.
* **Remoção de Anos Fixos:** Referências a edições passadas no texto institucional foram substituídas por `{eventDetails.year}` e `{eventDetails.lastYear}`.
* **Métricas Históricas Isoladas:** Como os números de engajamento do ano passado mudam a cada edição, decidi extrair os dados de *espectadores*, *inscritos* e *horas de conteúdo* para o objeto `lastYearStats` dentro do arquivo de configuração, alimentando o componente `<CountUp />` sem dados engessados no HTML.
* **Centralização de Links:** O link do regulamento (Google Docs) foi movido para o `eventDetails.js`, e a URL do *aftermovie embed* do YouTube foram movidas para o `data/socials.js, além da passagem dinâmica do link do canal do yotube ter sido feita.

###  Página da Comissão Organizadora (`pages/co.js`):
* **SEO & Indexação:** Refatoração  da tag `<Meta />`. Os campos de `description` e `keywords` que apontavam estaticamente para edições anteriores agora herdam o ano corrente dinamicamente através de *template literals*.
---

## Arquivos Modificados:
- `data/eventDetails.js` (Adicionadas propriedades `lastYear`, `regulationLink` e o objeto `lastYearStats`)
- `data/socials.js` (Adicionada a propriedade `aftermovieEmbed`)
- `pages/about.js` (Refatorado)
- `pages/co.js` (Refatorado)