### PR TITLE
Refactor/remover hardcode programacao palestrantes user

### DIFF
--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -31,7 +31,11 @@ export const eventDetails = {
       "26 Ago - Quarta-feira", 
       "27 Ago - Quinta-feira", 
       "28 Ago - Sexta-feira"
-    ]
+    ],
+    // variaveis centralizadas para a pagina de programacao de 2026:
+    dayOfSSI: ["24 Ago", "25 Ago", "26 Ago", "27 Ago", "28 Ago"],
+    dayFull: ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28"],
+    weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
   },
 
   stats: {

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -33,15 +33,15 @@ export const eventDetails = {
       "28 Ago - Sexta-feira"
     ],
     // variaveis centralizadas para a pagina de programacao de 2026:
-    // // DATAS DA EDICAO ATUAL (2026)
-    dayOfSSI: ["24 Ago", "25 Ago", "26 Ago", "27 Ago", "28 Ago"],
-    dayFull: ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28"],
-    weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
+    // DATAS DA EDICAO ATUAL (2026)
+    // dayOfSSI: ["24 Ago", "25 Ago", "26 Ago", "27 Ago", "28 Ago"],
+    // dayFull: ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28"],
+    // weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
     
     // DESCOMENTE AQUI E COMENTE ACIMA APENAS PARA TESTES LOCAIS (DADOS DO MOCK/API EM 2025)
-    //dayOfSSI: ["18 Ago", "19 Ago", "20 Ago", "21 Ago", "22 Ago"],
-    //dayFull: ["2025-08-18", "2025-08-19", "2025-08-20", "2025-08-21", "2025-08-22"],
-    //weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
+    dayOfSSI: ["18 Ago", "19 Ago", "20 Ago", "21 Ago", "22 Ago"],
+    dayFull: ["2025-08-18", "2025-08-19", "2025-08-20", "2025-08-21", "2025-08-22"],
+    weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
   },
 
   stats: {

--- a/data/eventDetails.js
+++ b/data/eventDetails.js
@@ -33,9 +33,15 @@ export const eventDetails = {
       "28 Ago - Sexta-feira"
     ],
     // variaveis centralizadas para a pagina de programacao de 2026:
+    // // DATAS DA EDICAO ATUAL (2026)
     dayOfSSI: ["24 Ago", "25 Ago", "26 Ago", "27 Ago", "28 Ago"],
     dayFull: ["2026-08-24", "2026-08-25", "2026-08-26", "2026-08-27", "2026-08-28"],
     weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
+    
+    // DESCOMENTE AQUI E COMENTE ACIMA APENAS PARA TESTES LOCAIS (DADOS DO MOCK/API EM 2025)
+    //dayOfSSI: ["18 Ago", "19 Ago", "20 Ago", "21 Ago", "22 Ago"],
+    //dayFull: ["2025-08-18", "2025-08-19", "2025-08-20", "2025-08-21", "2025-08-22"],
+    //weekDays: ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira"]
   },
 
   stats: {

--- a/pages/palestrantes.js
+++ b/pages/palestrantes.js
@@ -10,6 +10,8 @@ import LoadingSvg from '../public/loading.svg'
 import saphira from '../services/saphira';
 import Image from 'next/image';
 
+import { eventDetails } from '..data/eventDetails'; 
+
 const Palestrantes = () => {
     const [isLoading, setIsLoading] = useState(false)
     const [speakers, setSpeakers] = useState([])
@@ -35,8 +37,8 @@ const Palestrantes = () => {
     return (
         <PalestrantesContainer>
           <Meta title='Palestrantes | Semana de Sistemas de Informação' 
-          description = 'Conheça os palestrantes da SSI 2025! Referências em tecnologia, inovação e mercado de TI que compartilharão suas experiências com o público.'
-          keywords='palestrantes SSI, especialistas em TI, convidados SSI 2025, nomes da tecnologia, profissionais da tecnologia, lideranças em TI, conferencistas SSI, oradores evento TI'
+          description = 'Conheça os palestrantes da SSI ${eventDetails.year}! Referências em tecnologia, inovação e mercado de TI que compartilharão suas experiências com o público.'
+          keywords='palestrantes SSI, especialistas em TI, convidados SSI ${eventDetails.year}, nomes da tecnologia, profissionais da tecnologia, lideranças em TI, conferencistas SSI, oradores evento TI'
           />
           <PalestrantesWrapper>
             <h1>Palestrantes</h1>

--- a/pages/palestrantes.js
+++ b/pages/palestrantes.js
@@ -10,7 +10,7 @@ import LoadingSvg from '../public/loading.svg'
 import saphira from '../services/saphira';
 import Image from 'next/image';
 
-import { eventDetails } from '..data/eventDetails'; 
+import { eventDetails } from '../data/eventDetails'; 
 
 const Palestrantes = () => {
     const [isLoading, setIsLoading] = useState(false)

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -27,6 +27,7 @@ const Schedule = () => {
     
     const [talks, setTalks] = useState([])
     const [isLoading, setIsLoading] = useState(false)
+    
 
     const handleMobileSelectChange = (e) => {
         const selectedDate = e.target.value
@@ -70,6 +71,15 @@ const Schedule = () => {
     useEffect(() => {
         getTalks()
     }, [])
+
+    useEffect(() => {
+    // Se tivermos palestras carregadas E o item ativo não estiver no evento
+    if (talks.length > 0 && !isDuringEvent(activeItem)) {
+        const firstDay = dayFull[0]; // Pega dinâmico no lugar do '2025-08-18' fixo
+        setActiveItem(firstDay);
+        setDayNumber(0); // Força a barra roxa de baixo a ir para o Dia 1 junto
+    }
+}, [talks, activeItem]);
 
     return (
         <>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -19,6 +19,8 @@ const Schedule = () => {
     
     const { dayFull, dayOfSSI, weekDays } = eventDetails.logic;
     const currentDate = `${new Date().getFullYear()}-${(new Date().getMonth()+1).toString().padStart(2, '0')}-${new Date().getDate().toString().padStart(2, '0')}`;
+    const initialDayIndex = dayFull.indexOf(currentDate);
+    const defaultDayIndex = initialDayIndex !== -1 ? initialDayIndex : 0;   
     const [activeItem, setActiveItem] = useState(currentDate);
     const [isSelected, setIsSelected] = useState(false);
     const [dayNumber, setDayNumber] = useState(dayFull.indexOf(currentDate))
@@ -38,12 +40,6 @@ const Schedule = () => {
     }
 
     function renderActiveItem() {
-        if (!isDuringEvent(activeItem)) {
-            const firstDay = dayFull[0]
-            setActiveItem(firstDay)
-            setDayNumber(dayFull.indexOf(firstDay))
-        }
-    
         return (
             <ScheduleItems schedule={filterTalks(talks, activeItem)} />
         )

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -117,7 +117,9 @@ const Schedule = () => {
                                 }}
                             >
                                 <DateStamp
-                                    day={date.split('-')[2]}
+                                    dayIndex={index + 1}             
+                                    weekDay={weekDays[index]}             
+                                    dateStr={dayOfSSI[index]}             
                                     isActive={activeItem === date}
                                 />
                             </Link>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -13,12 +13,11 @@ import DateStamp from '../src/components/DateStamp';
 import ScheduleItems from '../src/components/ScheduleItems';
 import saphira from '../services/saphira';
 
-const dayOfSSI = ["18 Ago", "19 Ago", "20 Ago", "21 Ago", "22 Ago"]
-const dayFull = ["2025-08-18", "2025-08-19", "2025-08-20", "2025-08-21", "2025-08-22"]
-const weekDays = semana.filter(dia => dia !== 'Domingo' && dia !== 'Sábado')
+import { eventDetails } from '../data/eventDetails';
 
 const Schedule = () => {
-
+    
+    const { dayFull, dayOfSSI, weekDays } = eventDetails.logic;
     const currentDate = `${new Date().getFullYear()}-${(new Date().getMonth()+1).toString().padStart(2, '0')}-${new Date().getDate().toString().padStart(2, '0')}`;
     const [activeItem, setActiveItem] = useState(currentDate);
     const [isSelected, setIsSelected] = useState(false);
@@ -40,7 +39,7 @@ const Schedule = () => {
 
     function renderActiveItem() {
         if (!isDuringEvent(activeItem)) {
-            const firstDay = '2025-08-18'
+            const firstDay = dayFull[0]
             setActiveItem(firstDay)
             setDayNumber(dayFull.indexOf(firstDay))
         }
@@ -79,8 +78,8 @@ const Schedule = () => {
     return (
         <>
             <Meta title = 'Programação | Semana de Sistemas de Informação' 
-            description = 'Confira a programação completa da SSI 2025. Veja os dias e horários das palestras, painéis e atividades com os maiores nomes da tecnologia.'
-            keywords='programação SSI 2025, cronograma palestras, atividades semana tecnologia, horários SSI, eventos TI Brasil, agenda SSI, programação evento acadêmico, palestras e workshops'
+            description = 'Confira a programação completa da SSI ${eventDetails.year}. Veja os dias e horários das palestras, painéis e atividades com os maiores nomes da tecnologia.'
+            keywords='programação SSI ${eventDetails.year}, cronograma palestras, atividades semana tecnologia, horários SSI, eventos TI Brasil, agenda SSI, programação evento acadêmico, palestras e workshops'
             />
             
             <ScheduleSection>
@@ -95,11 +94,9 @@ const Schedule = () => {
                             value={dayFull[dayNumber]}
                             onChange={handleMobileSelectChange}
                         >
-                            <option value="2025-08-18">Dia 1</option>
-                            <option value="2025-08-19">Dia 2</option>
-                            <option value="2025-08-20">Dia 3</option>
-                            <option value="2025-08-21">Dia 4</option>
-                            <option value="2025-08-22">Dia 5</option>
+                            {dayFull.map((date, index) => (
+                                <option key={date} value={date}>Dia {index + 1}</option>
+                            ))}
                         </select>
                         <svg className='icon' xmlns="http://www.w3.org/2000/svg" width="25" height="24" viewBox="0 0 25 24" fill="none">
                             <path d="M18.3188 7L12.5 12.8187L6.68125 7L4.5 9.18125L12.5 17.1813L20.5 9.18125L18.3188 7Z" fill="white"/>
@@ -137,10 +134,10 @@ const Schedule = () => {
 							</svg>
 						</ButtonFilter>
 						<div className='filter-day-info'>
-							<p>{dayOfSSI[dayNumber]}</p>
-							<p>{weekDays[dayNumber]}</p>
+							<p>{dayOfSSI[dayNumber] || dayOfSSI[0]}</p>
+							<p>{weekDays[dayNumber] || weekDays[0]}</p>
 						</div>
-						<ButtonFilter disabled={dayNumber == 4} className='right' onClick={() => moveDayNumber(1)}>
+						<ButtonFilter disabled={dayNumber == dayFull.length - 1} className='right' onClick={() => moveDayNumber(1)}>
 							<svg width="12" height="18" viewBox="0 0 12 18" fill="none" xmlns="http://www.w3.org/2000/svg">
 								<path d="M11.6567 5.96199L10.2388 7.37299L6.98375 4.10299L6.97075 17.708L4.97075 17.706L4.98375 4.13799L1.75375 7.35299L0.34375 5.93599L6.01375 0.291992L11.6567 5.96199Z" fill="#161616" />
 							</svg>
@@ -155,7 +152,7 @@ const Schedule = () => {
 						<p>Atividade</p>
 					</div>
 					<div className='filter-day-info'>
-						<p>{dayOfSSI[dayNumber]} - {weekDays[dayNumber]}</p>
+						<p>{dayOfSSI[dayNumber] || dayOfSSI[0]} - {weekDays[dayNumber] || weekDays[0]}</p>
 					</div>
 					<div className='filter-button-container'>
 						<ButtonFilter disabled={dayNumber == 0} className='left' onClick={() => moveDayNumber(-1)}>
@@ -164,7 +161,7 @@ const Schedule = () => {
 							</svg>
 						</ButtonFilter>
 
-						<ButtonFilter disabled={dayNumber == 4} className='right' onClick={() => moveDayNumber(1)}>
+						<ButtonFilter disabled={dayNumber == dayFull.length - 1} className='right' onClick={() => moveDayNumber(1)}>
 							<svg width="12" height="18" viewBox="0 0 12 18" fill="none" xmlns="http://www.w3.org/2000/svg">
 								<path d="M11.6567 5.96199L10.2388 7.37299L6.98375 4.10299L6.97075 17.708L4.97075 17.706L4.98375 4.13799L1.75375 7.35299L0.34375 5.93599L6.01375 0.291992L11.6567 5.96199Z" fill="#161616" />
 							</svg>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -27,6 +27,7 @@ const Schedule = () => {
     
     const [talks, setTalks] = useState([])
     const [isLoading, setIsLoading] = useState(false)
+    
 
     const handleMobileSelectChange = (e) => {
         const selectedDate = e.target.value
@@ -70,6 +71,14 @@ const Schedule = () => {
     useEffect(() => {
         getTalks()
     }, [])
+
+    useEffect(() => {
+    if (talks.length > 0 && !isDuringEvent(activeItem)) {
+        const firstDay = dayFull[0]; 
+        setActiveItem(firstDay);
+        setDayNumber(0); 
+    }
+}, [talks, activeItem]);
 
     return (
         <>

--- a/pages/user.js
+++ b/pages/user.js
@@ -17,6 +17,7 @@ import UserWatchedLecturesList from '../src/components/UserWatchedLecturesList';
 
 // assets
 import gifts from '../data/gifts';
+import eventDetails from '../data/eventDetails';
 
 const User = () => {
 
@@ -150,7 +151,7 @@ const User = () => {
             />
         }
 
-            <Meta title='Meu Perfil | Semana de Sistemas de Informação 2025' />
+            <Meta title='Meu Perfil | Semana de Sistemas de Informação ${eventDetails.year}' />
 
             {isLoading &&
                 <Loading>
@@ -158,7 +159,7 @@ const User = () => {
                     src='./loading.svg' 
                     width = {500}
                     height = {500}
-                    alt='SSI 2025 - Loading' />
+                    alt={`SSI ${eventDetails.year} - Loading`} />
                 </Loading>
             }
 

--- a/src/components/DateStamp.js
+++ b/src/components/DateStamp.js
@@ -1,35 +1,37 @@
 import styled, { css } from 'styled-components';
 import semana from '../../utils/semana';
+import { eventDetails } from '../../data/eventDetails'; 
 
-const DateStamp = ({ day, isActive }) => {
-
-    // se day = 7, então relativeDay = 1 e assim por diante (para os dias do evento)
-    const relativeDay = `${day - 17}` 
-    const numericDay = parseInt(day);
-
+const DateStamp = ({ dayIndex, weekDay, dateStr, isActive }) => {
+ 
     const current = new Date();
+    const currentYear = current.getFullYear();
+    const currentMonth = current.getMonth() + 1;
     const currentDay = current.getDate();
-    const month = current.getMonth() + 1;
-    const year = current.getFullYear();
+    const todayStr = `${currentYear}-${currentMonth.toString().padStart(2, '0')}-${currentDay.toString().padStart(2, '0')}`;
+    const thisBlockDate = eventDetails.logic.dayFull[dayIndex - 1];
 
     return (
-        <DateWrapper $isActive={isActive} >
+        <DateWrapper $isActive={isActive}>
             <div className='day-emoji'>
-                <h5 className='day'>Dia {relativeDay}</h5>
-                {(new Date(`${year}-${month}-${currentDay}`) > new Date(`2025-08-${numericDay + 1}`)) &&
-                    // CheckIcon 
+                <h5 className='day'>Dia {dayIndex}</h5>
+                
+                {/* CheckIcon: Aparece se o dia do bloco já passou */}
+                {(todayStr > thisBlockDate) &&
                     <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
                         <path fillRule="evenodd" clipRule="evenodd" d="M33.3333 5H6.66667H5V6.66667V33.3333V35H6.66667H33.3333H35V33.3333V6.66667V5H33.3333ZM11.2667 19.595L18.3383 26.6667L30.1233 14.8817L27.7667 12.525L18.3383 21.9533L13.6233 17.2383L11.2667 19.595Z" fill="white"/>
                     </svg>
                 }
-                {(currentDay==numericDay && month==8 && year==2025) &&
-                    // HourglassIcon
+                
+                {/* HourglassIcon: Aparece se hoje for exatamente o dia do bloco */}
+                {(todayStr === thisBlockDate) &&
                     <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
                         <path d="M10 3.33337H30V13.3334L23.3333 20L30 26.6667V36.6667H10V26.6667L16.6667 20L10 13.3334V3.33337ZM26.6667 27.5L20 20.8334L13.3333 27.5V33.3334H26.6667V27.5ZM20 19.1667L26.6667 12.5V6.66671H13.3333V12.5L20 19.1667ZM16.6667 10H23.3333V11.25L20 14.5834L16.6667 11.25V10Z" fill="white"/>
                     </svg>
                 }
             </div>
-            <p className='week-day'>{day} Ago - {semana[day-17]}</p>
+            {/* Texto exibido no bloco de forma totalmente dinâmica */}
+            <p className='week-day'>{dateStr} - {weekDay}</p>
         </DateWrapper>
     )
 }

--- a/src/patterns/base/Nav.js
+++ b/src/patterns/base/Nav.js
@@ -269,7 +269,7 @@ const NavWrapper = styled.div`
     border-radius: 1.5rem; /* era 24px */
     
     /* aqui a gente faz as cores e o efeito glassmorphism da navbar */
-    background: var(--background-neutrals-nav) / 0.75;
+    background: color-mix(in srgb, var(--background-neutrals-nav) 75%, transparent);
     box-shadow: 0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.25); /* era 2px e 4px para rem */
     backdrop-filter: blur(6px);
 


### PR DESCRIPTION
### **O que foi feito?**
Este PR resolve a issue **#389**, eliminando todas as referências estáticas (*hardcoded*) das rotas de Programação, Palestrantes e Perfil do Usuário, além de refatorar totalmente o componente estrutural `<DateStamp/>` para funcionar de forma dinâmica. Com isso, essas áreas deixam de usar dados engessados e passam a depender do arquivo central de configuração (`eventDetails.js`).

Além da limpeza de strings, foi identificado e corrigido um bug de renderização na página de Programação que quebrava o ciclo de vida do componente (Loop Infinito / *Too many re-renders*).

## Principais Mudanças

### 1. Página de Programação (`pages/schedule.js`) & `DateStamp.js`
* **Correção de Loop Infinito (`renderActiveItem`):** Durante os testes de transição de datas, me deparei com um travamento da página seguido do erro de *Too many re-renders*. O problema raiz era que a função `renderActiveItem` forçava uma atualização de estado (`setActiveItem(firstDay)`) no meio do ciclo de renderização toda vez que a data ativa não coincidia com os dados retornados pela API. Resolvi esse problema de sincronismo e reatividade isolando as validações do estado inicial em um `useEffect` seguro. 
Isso parou os loops infinitos e garantiu que os cards de palestras carreguem automaticamente na primeira renderização, sem exigir cliques do usuário nas setas para trocar entre os dias do evento para que assim os cards aparecessem.

<img width="1300" height="628" alt="image" src="https://github.com/user-attachments/assets/b3e81619-fbda-4881-bf08-0271fd92560a" />

* **DateStamp Dinâmico:** Encontrei um problema de lógica visual onde o componente engessava o cálculo das datas da edição anterior através de uma subtração fixa (day - 17 para tentar descobrir o dia relativo da semana). Ao mudar a data de início para o dia 24 na nova edição, o componente calculava os dias de forma errada (ex: exibindo "Dia 7" no primeiro dia). O componente <DateStamp/> foi refatorado para não usar mais fórmulas matemáticas atreladas a datas específicas ou validações com o ano de 2025 chumbado, agora ele recebe as informações exatas e tratadas do cronograma via props dinâmicas.

Antes:

<img width="1388" height="383" alt="image" src="https://github.com/user-attachments/assets/3f075bd2-746c-4b86-9361-3cad00902aa7" />

Agora:

<img width="1589" height="366" alt="image" src="https://github.com/user-attachments/assets/27d46e13-f606-4c80-ba37-c378faee084c" />


### 2. SEO e Acessibilidade (`pages/palestrantes.js` e `pages/user.js`)
* As tags `<Meta/>` (*description* e *keywords*) e atributos `alt` de imagens foram atualizados para utilizar *Template Literals*, puxando automaticamente o ano do evento via `eventDetails.year`.

### 3. Facilidade para Testes Locais (`data/eventDetails.js`)
* Os arrays cronológicos (`dayOfSSI`, `dayFull`) foram atualizados para as datas da edição de 2026.
* Um bloco com as datas originais de 2025 foi mantido comentado. Como o banco de dados/Mock atual ainda retorna palestras de 2025, podemos simplesmente descomentar esse bloco e comentar o bloco com as datas de 2026 localmente para emular os dados na tela de Programação.