### PR TITLE
Componetizar schedulesection 393

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -22,6 +22,7 @@ import SecondaryButton from '../src/components/SecondaryButton';
 import YoutubeWatchNow from '../src/components/YoutubeWatchNow';
 import saphira from '../services/saphira';
 import CountdownSection from '../src/components/CountdownSection';
+import ScheduleSection from '../src/components/ScheduleSection';
 
 
 const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY

--- a/pages/index.js
+++ b/pages/index.js
@@ -262,8 +262,11 @@ const Home = () => {
                 </div>
             </EventInfoSection>
 
-            <ScheduleSection/>
-            
+            {(current >= eventDetails.logic.startJS && current <= eventDetails.logic.endJS) &&
+                <ScheduleSection />
+            }
+         
+
             <DirectionsSection>
                 <div className='directions-container'>
                     <div className='directions-info'>

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import useAuth from '../hooks/useAuth';
 import Meta from '../src/infra/Meta';
 import '../utils/slugify';
-import filterTalks from '../utils/filterTalks';
 import { eventDetails } from '../data/eventDetails';
 
 // importe Image do next
@@ -17,13 +16,10 @@ import AuthModal from '../src/components/AuthModal';
 import Button from '../src/components/Button';
 import MapModal from '../src/components/MapModal';
 import PartnerCard from '../src/components/PartnerCard';
-import ScheduleShift from '../src/components/ScheduleItems';
 import SecondaryButton from '../src/components/SecondaryButton';
 import YoutubeWatchNow from '../src/components/YoutubeWatchNow';
-import saphira from '../services/saphira';
 import CountdownSection from '../src/components/CountdownSection';
 import ScheduleSection from '../src/components/ScheduleSection';
-
 
 const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY
 
@@ -60,7 +56,6 @@ const Home = () => {
 
     const [showAuthModal, setShowAuthModal] = useState(false);
     const [showMapModal, setShowMapModal] = useState(false);
-    const [schedule, setSchedule] = useState([])
 
     const handleShowAuthModal = () => {
         setShowAuthModal(true);
@@ -69,82 +64,6 @@ const Home = () => {
     const handleShowMapModal = () => {
         setShowMapModal(true);
     }
-
-    const getSchedule = async() => {
-        try{
-            const { data } = await saphira.getTalks()
-            if (data) {
-                setSchedule(data)
-            }
-        }
-        catch(err){
-            console.log('Houve um erro na hora de obter os dados', err)
-        }
-    }
-
-    useEffect(() => {
-        getSchedule()
-    }, [])
-
-    const firstEventDay = new Date(2025, 7, 18);
-    const lastEventDay = new Date(2025, 7, 22);
-    // const firstEventDay = new Date(2026, 7, 24);
-    // const lastEventDay = new Date(2026, 7, 28);
-    //const firstEventDay = eventDetails.logic.startJS;
-    //const lastEventDay = eventDetails.logic.endJS;
-    lastEventDay.setHours(23, 59, 59, 999);  // Define para o final do dia (23:59:59.999)
-
-    const current = new Date();
-    const currentTime = current.getHours().toString().padStart(2, '0') + ":" + current.getMinutes().toString().padStart(2, '0')
-
-    const day = `${current.getDate()}`;
-
-    // Dia correto para o DateComponent
-    const scheduleDay = ((current >= firstEventDay && current <= lastEventDay) ? day : '18');
-
-    // Dia no formato yyyy-mm-dd para o ScheduleShift
-    const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
-
-    // Se a data atual estiver entre o primeiro e o último dia do evento, use a data atual; caso contrário, use a data do primeiro dia do evento (fallback)
-    const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
-
-    const filterEventDays = eventDetails.logic.filterEventDays;
-    const filterEventDaysId = scheduleDay - firstEventDay.getDate();
-
-    // Transforma 00:00 em minutos depois da meia noite para fazer calculos
-    const minutesAfterMidNight = (time) => {
-        const [hours, minutes] = time.split(":").map(Number);
-        return hours * 60 + minutes;
-    }
-
-    const currentTimeMinutes = minutesAfterMidNight(currentTime); // horario atual
-    const morningEnd = minutesAfterMidNight("12:00"); // Início do almoco
-    const eveningEnd = minutesAfterMidNight("18:00"); // Início do jantar
-
-    let shift = "Manhã"; // Turno do dia
-    if (current >= firstEventDay) {
-        if (currentTimeMinutes >= morningEnd && currentTimeMinutes < eveningEnd) {
-            shift = "Tarde";
-        } else if (currentTimeMinutes >= eveningEnd) {
-            shift = "Noite";
-        }
-    }
-
-    // Array intermediario com de horario e atividades
-    const filteredArray = schedule.filter((array) => {
-        const scheduleStartTimeMinutes = minutesAfterMidNight(array.start_time.split("T")[1]); // Horário de cada atividade
-        switch (shift) {
-            case "Manhã":
-                return scheduleStartTimeMinutes < morningEnd;
-            case "Tarde":
-                return scheduleStartTimeMinutes > morningEnd && scheduleStartTimeMinutes < eveningEnd;
-            case "Noite":
-                return scheduleStartTimeMinutes > eveningEnd;
-        }
-    })
-
-    // Cria um object com base no array intermediario
-    const filteredSchedule = filterTalks(filteredArray, formattedScheduleDate)
    
     useEffect(() => {
         if (showAuthModal) {
@@ -173,6 +92,8 @@ const Home = () => {
             document.body.style.paddingRight = 'unset';
         }
     }, [showMapModal]); 
+
+    const current = new Date();
 
     // Verifica se a data atual é anterior ao início do evento para exibir a contagem regressiva na LandingSection
     const isCronologicallyBeforeEvent = current < eventDetails.logic.startJS;
@@ -341,46 +262,8 @@ const Home = () => {
                 </div>
             </EventInfoSection>
 
-
-
-            {(current <= lastEventDay) &&
-                <ScheduleSection>
-                    <div className='schedule-container'>
-                        <h3 className='title-mobile schedule-section-title'>Próximas atividades</h3>
-                        <div className='title-btn-desktop'>
-                            <h3 className='schedule-section-title'>Próximas atividades</h3>
-                            <Button type="button" aria-label="Ver programação completa" onClick={() => router.push('/schedule')}>Ver programação completa</Button>
-                        </div>
-                        <div className='filter-bar-container filter-bar-mobile'>
-                            <p>Dia {filterEventDaysId + 1} - {filterEventDays[filterEventDaysId]}</p>
-                            <p>{shift}</p>
-                        </div>
-
-                        <div className='filter-bar-container filter-bar-desktop'>
-                            <div className='subtitle'>
-                                <p>Horário</p>
-                                <p>Atividade</p>
-                            </div>
-
-                            <div>
-                                <p>Dia {filterEventDaysId + 1} - {filterEventDays[filterEventDaysId]}</p>
-                            </div>
-
-                            <div>
-                                <p>{shift}</p>
-                            </div>
-                        </div>
-
-                        <ScheduleShift
-                            schedule={filteredSchedule}
-                        />
-                        <div className='btn-mobile'>
-                            <Button onClick={() => router.push('/schedule')}>Ver programação completa</Button>
-                        </div>
-                    </div>
-                </ScheduleSection>
-            }
-
+            <ScheduleSection/>
+            
             <DirectionsSection>
                 <div className='directions-container'>
                     <div className='directions-info'>

--- a/src/components/ScheduleSection.js
+++ b/src/components/ScheduleSection.js
@@ -1,0 +1,239 @@
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+
+import Button from './Button';
+import ScheduleShift from './ScheduleItems';
+import saphira from '../../services/saphira';
+import filterTalks from '../../utils/filterTalks';
+import { eventDetails } from '../../data/eventDetails';
+
+const ScheduleSection = () => {
+    const router = useRouter();
+    const [schedule, setSchedule] = useState([]);
+
+    const getSchedule = async() => {
+        try{
+            const { data } = await saphira.getTalks()
+            if (data) {
+                setSchedule(data)
+            }
+        }
+        catch(err){
+            console.log('Houve um erro na hora de obter os dados', err)
+        }
+    }
+
+    useEffect(() => {
+        getSchedule()
+    }, [])
+
+    const firstEventDay = new Date(2025, 7, 18);
+    const lastEventDay = new Date(2025, 7, 22);
+    lastEventDay.setHours(23, 59, 59, 999);  // define para o final do dia (23:59:59.999)
+
+    // MOCK DE DATA PARA TESTES LOCAIS:
+    // const current = new Date(2025, 7, 19); 
+    const current = new Date(); 
+
+    const currentTime = current.getHours().toString().padStart(2, '0') + ":" + current.getMinutes().toString().padStart(2, '0')
+
+    const day = `${current.getDate()}`;
+
+    const scheduleDay = ((current >= firstEventDay && current <= lastEventDay) ? day : '18');
+    const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
+    // se a data atual estiver entre o primeiro e o ultimo dia do evento, use a data atual, caso contrario, use a data do primeiro dia do evento (fallback)
+    const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;
+
+    const filterEventDays = eventDetails.logic.filterEventDays;
+    const filterEventDaysId = scheduleDay - firstEventDay.getDate();
+
+    // transforma 00:00 em minutos depois da meia noite para fazer calculos
+    const minutesAfterMidNight = (time) => {
+        const [hours, minutes] = time.split(":").map(Number);
+        return hours * 60 + minutes;
+    }
+
+    const currentTimeMinutes = minutesAfterMidNight(currentTime); // horario atual
+    const morningEnd = minutesAfterMidNight("12:00"); 
+    const eveningEnd = minutesAfterMidNight("18:00"); 
+
+    let shift = "Manhã"; 
+    if (current >= firstEventDay) {
+        if (currentTimeMinutes >= morningEnd && currentTimeMinutes < eveningEnd) {
+            shift = "Tarde";
+        } else if (currentTimeMinutes >= eveningEnd) {
+            shift = "Noite";
+        }
+    }
+
+    // Array intermediario com de horario e atividades
+    const filteredArray = schedule.filter((array) => {
+        const scheduleStartTimeMinutes = minutesAfterMidNight(array.start_time.split("T")[1]); // Horário de cada atividade
+        switch (shift) {
+            case "Manhã":
+                return scheduleStartTimeMinutes < morningEnd;
+            case "Tarde":
+                return scheduleStartTimeMinutes > morningEnd && scheduleStartTimeMinutes < eveningEnd;
+            case "Noite":
+                return scheduleStartTimeMinutes > eveningEnd;
+            default:
+                return false;
+        }
+    })
+
+    const filteredSchedule = filterTalks(filteredArray, formattedScheduleDate)
+
+    if (current > lastEventDay) return null;
+
+    return (
+        <SectionWrapper>
+            <div className='schedule-container'>
+                <h3 className='title-mobile schedule-section-title'>Próximas atividades</h3>
+                <div className='title-btn-desktop'>
+                    <h3 className='schedule-section-title'>Próximas atividades</h3>
+                    <Button type="button" aria-label="Ver programação completa" onClick={() => router.push('/schedule')}>Ver programação completa</Button>
+                </div>
+                <div className='filter-bar-container filter-bar-mobile'>
+                    <p>Dia {filterEventDaysId + 1} - {filterEventDays[filterEventDaysId]}</p>
+                    <p>{shift}</p>
+                </div>
+
+                <div className='filter-bar-container filter-bar-desktop'>
+                    <div className='subtitle'>
+                        <p>Horário</p>
+                        <p>Atividade</p>
+                    </div>
+
+                    <div>
+                        <p>Dia {filterEventDaysId + 1} - {filterEventDays[filterEventDaysId]}</p>
+                    </div>
+
+                    <div>
+                        <p>{shift}</p>
+                    </div>
+                </div>
+
+                <ScheduleShift
+                    schedule={filteredSchedule}
+                />
+                <div className='btn-mobile'>
+                    <Button onClick={() => router.push('/schedule')}>Ver programação completa</Button>
+                </div>
+            </div>
+        </SectionWrapper>
+    );
+};
+
+export default ScheduleSection;
+
+const ScheduleSection = styled.section`
+    padding-block: 2rem;
+    border-top: 1px solid var(--outline-neutrals-secondary);
+    
+    .schedule-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
+
+        .schedule-section-title {
+            background-color: var(--brand-primary);
+            padding: 0.75rem 1.5rem 0.75rem 1.5rem;
+            color: var(--content-neutrals-fixed-white);
+        }
+
+        .title-mobile {
+            display: flex;
+            flex-direction: row;
+            background-color: var(--brand-primary);
+            padding: 0.75rem 1.5rem 0.75rem 1.5rem;
+        }
+
+        .title-btn-desktop {
+            display: none;
+        }
+
+        .filter-bar-container {
+            height: fit-content;
+            padding-block: 1rem;
+            width: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            box-shadow: 0 -0.0625rem 0 0 var(--background-neutrals-secondary);
+            border-bottom: 0.0625rem solid var(--outline-neutrals-secondary);
+
+            p {
+                font: 700 1rem/1.25rem 'AT Aero Bold';
+            }
+        }
+
+        .filter-bar-mobile {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            margin-bottom: -1rem;
+
+            @media (min-width: 1024px) {
+                display: none;
+            }
+        }
+
+        .filter-bar-desktop {
+            margin-bottom: -2rem;
+
+            @media (max-width: 1023px) {
+                display: none;
+            }
+
+            justify-content: space-between;
+            
+            .subtitle {
+                display: flex;
+                gap: 6.31rem;
+            }
+        }
+
+        .date-stamp {
+            > div {
+                background-color: var(--brand-primary);
+            }
+        }
+
+        .btn-mobile {
+            width: 100%;
+        }
+    }
+
+    @media (min-width:1021px) {
+        padding-block: 4.5rem 2rem;
+
+        .schedule-container {
+            gap: 1.5rem;
+            align-items: flex-start;
+
+            .title-mobile {
+                display: none;
+            }
+
+            .title-btn-desktop {
+                width: 100%;
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                justify-content: space-between;
+
+                button {
+                    width: fit-content;
+                }
+            }
+
+            .btn-mobile {
+                display: none;
+            }
+        }
+    }
+`;

--- a/src/components/ScheduleSection.js
+++ b/src/components/ScheduleSection.js
@@ -28,17 +28,19 @@ const ScheduleSection = () => {
         getSchedule()
     }, [])
 
-    const firstEventDay = eventDetails.logic.startJS; // 24 de agosto de 2026
+    
+    // MOCK DE DATA PARA TESTES LOCAIS:
+    //const firstEventDay = new Date(2025, 7, 18);
+    //const lastEventDay = new Date(2025, 7, 22);
+    //const current = new Date(2025, 7, 18); 
 
+    const current = new Date();
+    const firstEventDay = eventDetails.logic.startJS; 
     // criei uma copia do endJS (new Date) para que o setHours 
     // nao altere a variável original lá do eventDetails globalmente
-    const lastEventDay = new Date(eventDetails.logic.endJS); // 28 de agosto de 2026
+    const lastEventDay = new Date(eventDetails.logic.endJS); 
 
     lastEventDay.setHours(23, 59, 59, 999);  // define para o final do dia (23:59:59.999)
-
-    // MOCK DE DATA PARA TESTES LOCAIS:
-    //const current = new Date(2025, 7, 21); 
-    const current = new Date(); 
 
     const currentTime = current.getHours().toString().padStart(2, '0') + ":" + current.getMinutes().toString().padStart(2, '0')
 

--- a/src/components/ScheduleSection.js
+++ b/src/components/ScheduleSection.js
@@ -33,7 +33,7 @@ const ScheduleSection = () => {
     lastEventDay.setHours(23, 59, 59, 999);  // define para o final do dia (23:59:59.999)
 
     // MOCK DE DATA PARA TESTES LOCAIS:
-    // const current = new Date(2025, 7, 19); 
+    //const current = new Date(2025, 7, 21); 
     const current = new Date(); 
 
     const currentTime = current.getHours().toString().padStart(2, '0') + ":" + current.getMinutes().toString().padStart(2, '0')
@@ -121,13 +121,13 @@ const ScheduleSection = () => {
                     <Button onClick={() => router.push('/schedule')}>Ver programação completa</Button>
                 </div>
             </div>
-        </SectionWrapper>
+            </SectionWrapper>
     );
 };
 
 export default ScheduleSection;
 
-const ScheduleSection = styled.section`
+const SectionWrapper = styled.section`
     padding-block: 2rem;
     border-top: 1px solid var(--outline-neutrals-secondary);
     

--- a/src/components/ScheduleSection.js
+++ b/src/components/ScheduleSection.js
@@ -28,8 +28,12 @@ const ScheduleSection = () => {
         getSchedule()
     }, [])
 
-    const firstEventDay = new Date(2025, 7, 18);
-    const lastEventDay = new Date(2025, 7, 22);
+    const firstEventDay = eventDetails.logic.startJS; // 24 de agosto de 2026
+
+    // criei uma copia do endJS (new Date) para que o setHours 
+    // nao altere a variável original lá do eventDetails globalmente
+    const lastEventDay = new Date(eventDetails.logic.endJS); // 28 de agosto de 2026
+
     lastEventDay.setHours(23, 59, 59, 999);  // define para o final do dia (23:59:59.999)
 
     // MOCK DE DATA PARA TESTES LOCAIS:
@@ -40,7 +44,8 @@ const ScheduleSection = () => {
 
     const day = `${current.getDate()}`;
 
-    const scheduleDay = ((current >= firstEventDay && current <= lastEventDay) ? day : '18');
+    const fallbackDay = firstEventDay.getDate().toString();
+    const scheduleDay = ((current >= firstEventDay && current <= lastEventDay) ? day : fallbackDay);
     const todayDate = current.toLocaleDateString('pt-br').split('/').reverse().join('-');
     // se a data atual estiver entre o primeiro e o ultimo dia do evento, use a data atual, caso contrario, use a data do primeiro dia do evento (fallback)
     const formattedScheduleDate = current >= firstEventDay && current <= lastEventDay ? todayDate : eventDetails.logic.fallbackString;


### PR DESCRIPTION
### O que foi feito
Este PR resolve a issue **#393**, realizando a extração e componentização de toda a lógica e estrutura do cronograma que antes poluíam a página principal (`pages/index.js`). Toda a seção foi movida para um componente isolado em `src/components/ScheduleSection.js`.

Aproveitando a refatoração, as lógicas de controle de data e filtros de turno (Manhã, Tarde, Noite), que antes possuíam referências estáticas (*hardcoded*), foram atualizadas para consumir os dados dinamicamente a partir do `eventDetails.js`, deixando o componente pronto para edições futuras.

##  Principais Mudanças

### 1. Criação do Componente (`src/components/ScheduleSection.js`)
* **Isolamento de Escopo:** Toda a lógica matemática de cálculo de minutos, definição de turnos e filtragem de palestras por horário foi encapsulada no novo componente.
* **Estilização Blindada:** Foi aplicada estritamente a estilização via *styled-components* fornecida na issue, evitando a quebra de layout na Home e corrigindo o conflito de nomenclatura no arquivo através da constante `SectionWrapper`.
* **Datas Dinâmicas:** Substituição das referências fixas de 2025 pelas propriedades `eventDetails.logic.startJS` e `eventDetails.logic.endJS`.

### 2. Limpeza da Home (`pages/index.js`)
* Remoção de estados (`schedule`), funções de busca (`getSchedule`), *imports* mortos (`saphira`, `filterTalks`, `ScheduleShift`) e blocos extensos de código no JSX.
* A página principal agora importa e renderiza apenas a tag limpa `<ScheduleSection />`.

### 3. Ciclo de Vida e Exibição Recíproca
* Foi mantida a regra de negócio onde a seção de próximas atividades só deve ser renderizada durante o período do evento.
