### PR TITLE
[UI/Refactor] Atualizar design das Badges de Setor

### DIFF
--- a/src/components/features/co/MemberCard.js
+++ b/src/components/features/co/MemberCard.js
@@ -13,32 +13,22 @@ const colorSchemes = [
     {
         'background' : 'var(--background-neutrals-inverse)',
         'textColor' : 'var(--content-neutrals-inverse)',
-        'directorBadge' : 1,
-        'badgeSequence' : [3, 9, 6, 8, 5, 4]
     },
     {
         'background' : 'var(--background-neutrals-secondary)',
         'textColor' : 'var(--content-neutrals-secondary)',
-        'directorBadge' : 1,
-        'badgeSequence' : [3, 9, 6, 8, 5, 4]
     },
     {
         'background' : 'var(--brand-primary)',
         'textColor' : 'var(--content-neutrals-fixed-white)',
-        'directorBadge' : 1,
-        'badgeSequence' : [3, 9, 8, 4]
     },
     {
         'background' : 'var(--brand-primary-light)',
         'textColor' : 'var(--content-neutrals-fixed-black)',
-        'directorBadge' : 1,
-        'badgeSequence' : [5, 6, 7, 4]
     },   
     {
         'background' : 'var(--brand-primary-dark)',
         'textColor' : 'var(--content-neutrals-fixed-white)',
-        'directorBadge' : 1,
-        'badgeSequence' : [9, 5, 4]
     },
 ]
 
@@ -128,13 +118,9 @@ const MemberCard = ({ name, image, departments, linkedin, colorScheme, phrase })
                     <p className='department-title'>Setores</p>
                     
                     <div className='member-department'>
-                        {sortDepartments(departments).map((department, index) => {
-                            let badges = currentTheme.badgeSequence;
-                            if(department === 'Diretoria')
-                                return <BadgeCO key={index} text={department} themeIndex={currentTheme.directorBadge}/>
-                            
-                            return <BadgeCO key={index} text={department} themeIndex={badges[index % badges.length]}/>
-                        })}
+                        {sortDepartments(departments).map((department, index) => (
+                            <BadgeCO key={index} text={department} />
+                        ))}
                     </div>
                 </div>
             </div>

--- a/src/components/ui/BadgeCO.js
+++ b/src/components/ui/BadgeCO.js
@@ -65,7 +65,7 @@ const BadgeWrapper = styled.div`
     border: 2px solid ${props => props.$borderColor};
 
     p {
-        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "AT Aero Bold", sans-serif);
+        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "At Hauss Aero", sans-serif);
         font-size: 0.875rem;
         font-weight: 700;
         line-height: 1.5rem; 

--- a/src/components/ui/BadgeCO.js
+++ b/src/components/ui/BadgeCO.js
@@ -1,68 +1,52 @@
 import styled from "styled-components";
 
 /**
- * Paleta de temas disponíveis para o Badge.
- * Utiliza variáveis CSS do Design System global para garantir consistência.
- * O índice (0 a 9) deste array é utilizado na prop 'themeIndex' do componente.
+ * Retorna as cores da borda e do texto com base no nome do setor.
+ * As cores foram mapeadas conforme o Figma atualizado.
  */
-const colorSchemes = [
-    {
-        'badgeColor' : 'var(--background-neutrals-inverse)',
-        'textColor'  : 'var(--content-neutrals-inverse)'
-    },
-    {
-        'badgeColor' : 'var(--background-neutrals-primary)',
-        'textColor'  : 'var(--content-neutrals-primary)'
-    },
-    {
-        'badgeColor' : 'var(--brand-purple-200)',
-        'textColor'  : 'var(--content-neutrals-inverse)'
-    },
-    {
-        'badgeColor' : 'var(--brand-purple-300)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },
-    {
-        'badgeColor' : 'var(--brand-purple-400)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },
-    {
-        'badgeColor' : 'var(--brand-purple-500)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },
-    {
-        'badgeColor' : 'var(--brand-purple-600)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },
-    {
-        'badgeColor' : 'var(--brand-purple-700)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },    
-    {
-        'badgeColor' : 'var(--brand-purple-800)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },    
-    {
-        'badgeColor' : 'var(--brand-purple-900)',
-        'textColor'  : 'var(--content-neutrals-fixed-white)'
-    },
-]
+const getBadgeColors = (text) => {
+    switch (text) {
+        case 'Diretoria':
+        case 'Parcerias':
+            return {
+                color: 'var(--content-neutrals-primary, #FFF)',
+                borderColor: 'var(--content-neutrals-primary, #FFF)'
+            };
+        case 'Criação e Comunicação':
+        case 'Palestrantes':
+            return {
+                color: '#9638FF',
+                borderColor: '#9638FF' // var(--brand-primary) ou equivalente, se existir no projeto
+            };
+        case 'Comercial e Financeiro':
+        case 'Infraestrutura':
+        case 'Sites':
+            return {
+                // A cor do texto para esses setores no Figma também era #9638FF,
+                // mas a borda é mais clara
+                color: '#9638FF', 
+                borderColor: 'var(--purple-light-purple, #D0ACFF)'
+            };
+        default:
+            // Cor de fallback caso adicionem um novo setor no futuro
+            return {
+                color: 'var(--content-neutrals-primary, #FFF)',
+                borderColor: 'var(--content-neutrals-primary, #FFF)'
+            };
+    }
+};
 
 /**
- * Componente de etiqueta (Badge) flexível para categorização e status.
+ * Componente de etiqueta (Badge) para setores da Comissão Organizadora.
  * 
  * @param {Object} props
- * @param {string} props.text - O texto que será exibido dentro do badge.
- * @param {number} props.themeIndex - Índice numérico (0 a 9) que seleciona a combinação de cores do colorSchemes.
- * @param {boolean} props.rounded - Define o formato: 'true' aplica bordas arredondadas e fonte menor; 'false' aplica bordas retas e fonte padrão.
- * 
- * @example
- * <BadgeCO text="Novo" themeIndex={3} rounded={true} />
+ * @param {string} props.text - O texto/setor que será exibido dentro do badge.
  */
-const BadgeCO = ({ text, themeIndex, rounded }) => {
+const BadgeCO = ({ text }) => {
+    const { color, borderColor } = getBadgeColors(text);
+
     return (
-        // Utilizamos o prefixo '$' (Transient Props) para evitar que essas propriedades vazem para o HTML final
-        <BadgeWrapper $themeIndex={themeIndex} $rounded={rounded}>
+        <BadgeWrapper $color={color} $borderColor={borderColor}>
             <p>{text}</p>
         </BadgeWrapper>
     )
@@ -70,25 +54,23 @@ const BadgeCO = ({ text, themeIndex, rounded }) => {
 
 export default BadgeCO;
 
-
 const BadgeWrapper = styled.div`
-    /* Ajusta a largura para envolver perfeitamente o texto e permite renderização lado a lado */
     width: fit-content;
-    display: inline-block;
-    padding: 0rem 0.25rem;
-
-    /* A cor de fundo é recuperada dinamicamente do array utilizando o índice recebido via prop */
-    background-color: ${props => colorSchemes[props.$themeIndex].badgeColor};
-    
-    /* Alterna o arredondamento (border-radius) baseado na prop $rounded */
-    border-radius: ${props => props.$rounded ? '0.375rem' : '0'};
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.3125rem 0.625rem; 
+    border-radius: 0.1875rem; 
+    background-color: transparent;
+    border: 2px solid ${props => props.$borderColor};
 
     p {
-        /* A prop $rounded também influencia o tamanho da fonte */
-        font-size: ${props => props.$rounded ? '0.75rem' : '0.875rem'};
-        font-weight: 400;
+        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "AT Aero Bold", sans-serif);
+        font-size: 0.875rem;
+        font-weight: 700;
+        line-height: 1.5rem; 
         
-        /* A cor do texto também acompanha a paleta selecionada pelo themeIndex */
-        color: ${props => colorSchemes[props.$themeIndex].textColor};
+        color: ${props => props.$color};
+        margin: 0; 
     }
-`
+`;

--- a/src/components/ui/BadgeCO.js
+++ b/src/components/ui/BadgeCO.js
@@ -1,32 +1,39 @@
 import styled from "styled-components";
 
-const getBadgeColors = (text) => {
-    switch (text) {
-        case 'Diretoria':
-        case 'Parcerias':
-            return {
-                color: 'var(--content-neutrals-primary, #FFF)',
-                borderColor: 'var(--content-neutrals-primary, #FFF)'
-            };
-        case 'Criação e Comunicação':
-        case 'Palestrantes':
-            return {
-                color: '#9638FF',
-                borderColor: '#9638FF'
-            };
-        case 'Comercial e Financeiro':
-        case 'Infraestrutura':
-        case 'Sites':
-            return {
-                color: '#9638FF', 
-                borderColor: 'var(--purple-light-purple, #D0ACFF)'
-            };
-        default:
-            return {
-                color: 'var(--content-neutrals-primary, #FFF)',
-                borderColor: 'var(--content-neutrals-primary, #FFF)'
-            };
+const badgeColorsMap = {
+    'Diretoria' : { 
+        color: 'var(--content-neutrals-primary)', 
+        borderColor: 'var(--content-neutrals-primary)' 
+    },
+    'Parcerias' : { 
+        color: 'var(--content-neutrals-primary)', 
+        borderColor: 'var(--content-neutrals-primary)' 
+    },
+    'Criação e Comunicação': { 
+        color: 'var(--brand-purple-500)', 
+        borderColor: 'var(--brand-purple-500)' 
+    },
+    'Palestrantes': { 
+        color: 'var(--brand-purple-500)', 
+        borderColor: 'var(--brand-purple-500)' 
+    },
+    'Comercial e Financeiro': { 
+        color: 'var(--brand-purple-500)', 
+        borderColor: 'var(--brand-purple-200)' 
+    },
+    'Infraestrutura': { 
+        color: 'var(--brand-purple-500)', 
+        borderColor: 'var(--brand-purple-200)' 
+    },
+    'Sites': { 
+        color: 'var(--brand-purple-500)', 
+        borderColor: 'var(--brand-purple-200)' 
     }
+};
+
+const defaultColors = {
+    color: 'var(--content-neutrals-primary)', 
+    borderColor: 'var(--content-neutrals-primary)' 
 };
 
 /**
@@ -36,8 +43,8 @@ const getBadgeColors = (text) => {
  * @param {string} props.text 
  */
 const BadgeCO = ({ text }) => {
-    const { color, borderColor } = getBadgeColors(text);
-
+    const { color, borderColor } = badgeColorsMap[text] || defaultColors;
+    
     return (
         <BadgeWrapper $color={color} $borderColor={borderColor}>
             <p>{text}</p>
@@ -58,7 +65,7 @@ const BadgeWrapper = styled.div`
     border: 2px solid ${props => props.$borderColor};
 
     p {
-        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "At Hauss Aero", sans-serif); // essa fonte nao esta sendo 100% fiel ao que estamos esperando, precisamos investigar depois para ficar igual ao figma
+        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "At Hauss Aero", sans-serif); 
         font-size: 0.875rem;                                                                            
         font-weight: 700;
         line-height: 1.5rem; 

--- a/src/components/ui/BadgeCO.js
+++ b/src/components/ui/BadgeCO.js
@@ -1,9 +1,5 @@
 import styled from "styled-components";
 
-/**
- * Retorna as cores da borda e do texto com base no nome do setor.
- * As cores foram mapeadas conforme o Figma atualizado.
- */
 const getBadgeColors = (text) => {
     switch (text) {
         case 'Diretoria':
@@ -16,19 +12,16 @@ const getBadgeColors = (text) => {
         case 'Palestrantes':
             return {
                 color: '#9638FF',
-                borderColor: '#9638FF' // var(--brand-primary) ou equivalente, se existir no projeto
+                borderColor: '#9638FF'
             };
         case 'Comercial e Financeiro':
         case 'Infraestrutura':
         case 'Sites':
             return {
-                // A cor do texto para esses setores no Figma também era #9638FF,
-                // mas a borda é mais clara
                 color: '#9638FF', 
                 borderColor: 'var(--purple-light-purple, #D0ACFF)'
             };
         default:
-            // Cor de fallback caso adicionem um novo setor no futuro
             return {
                 color: 'var(--content-neutrals-primary, #FFF)',
                 borderColor: 'var(--content-neutrals-primary, #FFF)'
@@ -40,7 +33,7 @@ const getBadgeColors = (text) => {
  * Componente de etiqueta (Badge) para setores da Comissão Organizadora.
  * 
  * @param {Object} props
- * @param {string} props.text - O texto/setor que será exibido dentro do badge.
+ * @param {string} props.text 
  */
 const BadgeCO = ({ text }) => {
     const { color, borderColor } = getBadgeColors(text);
@@ -65,8 +58,8 @@ const BadgeWrapper = styled.div`
     border: 2px solid ${props => props.$borderColor};
 
     p {
-        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "At Hauss Aero", sans-serif);
-        font-size: 0.875rem;
+        font-family: var(--Typograph-Main-Font-Family-At-Hauss-Aero, "At Hauss Aero", sans-serif); // essa fonte nao esta sendo 100% fiel ao que estamos esperando, precisamos investigar depois para ficar igual ao figma
+        font-size: 0.875rem;                                                                            
         font-weight: 700;
         line-height: 1.5rem; 
         


### PR DESCRIPTION
## O que foi feito

Esta PR atualiza o design visual das badges de setores no card da Comissão Organizadora.
**Resolvendo a issue #421** (Listada na #422).

---

## Alterações Realizadas

### `src/components/ui/BadgeCO.js`

- Remoção das props obsoletas `rounded` e `themeIndex`.
- Criação de mapeamento estático de cores (`getBadgeColors`) via `switch/case` baseado no nome do setor (ex: Diretoria, Criação e Comunicação, etc).
- Atualização do styled-components para o estilo **outline** (fundo transparente e borda colorida).
- Aplicação dos novos paddings, `border-radius: 3px` e padronização da tipografia global (`AT Aero Bold`, `14px`, peso `700`).

### `src/components/features/co/MemberCard.js`

- Limpeza do array `colorSchemes`, removendo as lógicas cíclicas de `directorBadge` e `badgeSequence` que não são mais necessárias.
- Simplificação da renderização das badges no JSX, removendo as condicionais matemáticas e passando apenas a prop `text`.

---

## Issues Relacionadas

- **Closes** #421  
- **Refs** #422