### PR TITLE
feat: mostrando barra fixed de alterar dia na versão desktop

### DIFF
--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -27,6 +27,7 @@ const Schedule = () => {
     const defaultDayIndex = initialDayIndex !== -1 ? initialDayIndex : 0;   
     const [activeItem, setActiveItem] = useState(currentDate);
     const [dayNumber, setDayNumber] = useState(defaultDayIndex)
+    const [desktopShow, setDesktopShow] = useState(false);
     
     const [talks, setTalks] = useState([])
     const [isLoading, setIsLoading] = useState(false)
@@ -83,6 +84,20 @@ const Schedule = () => {
     const selectedWeekDay = weekDays[dayNumber] || weekDays[0];
     const shouldRenderEtecItinerary = selectedWeekDay === 'Terça-feira' || selectedWeekDay === 'Quinta-feira';
 
+    // Observa se o filtro de dias (desktop) está visível na tela. Se não estiver, define a variável para exibir a barra de filtro fixed.
+    useEffect(() => {
+        const elemento = document.querySelector(".desktop-selection");
+        if (!elemento) return;
+
+        const observer = new IntersectionObserver(([entry]) => {
+            setDesktopShow(!entry.isIntersecting);
+        },{ threshold: 0 });
+
+        observer.observe(elemento);
+
+        return () => observer.disconnect();
+    }, []);
+
     return (
         <>
             <Meta title = 'Programação | Semana de Sistemas de Informação' 
@@ -94,7 +109,7 @@ const Schedule = () => {
                 <h1>Programação</h1>
 
                 {/* Filtro Desktop */}
-                <DesktopSelectionContainer>
+                <DesktopSelectionContainer className='desktop-selection'>
                     <div className='schedule-container'>
                         {dayFull.map((date, index) => (
                             <Link
@@ -117,7 +132,7 @@ const Schedule = () => {
                 </DesktopSelectionContainer>
                 {/* Barra de filtro Mobile */}
                 <StickyBackground/>
-				<MobileBarFilterContainer>
+				<MobileBarFilterContainer $desktopShow={desktopShow}>
 					<div className='filter-container'>
 						<ButtonFilter disabled={dayNumber == 0} className='left' onClick={() => moveDayNumber(-1)}>
 							<svg width="12" height="18" viewBox="0 0 12 18" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -183,10 +198,6 @@ const StickyBackground = styled.div`
     color: var(--content-neutrals-primary);
     background-color: var(--background-neutrals-primary);
     height: 1rem;
-
-    @media (min-width:801px) {
-        display: none;
-    }
 `
 
 const MobileBarFilterContainer = styled.div`
@@ -221,8 +232,17 @@ const MobileBarFilterContainer = styled.div`
         }
     }
 
-	@media(min-width:801px) {
-		display: none;
+	@media (min-width:801px) {
+		display: ${props => props.$desktopShow ? 'block' : 'none'};
+        position: fixed;
+        left: 1rem;
+        right: 1rem;
+        width: auto;
+        margin: auto;
+
+        .filter-container {
+            height: 5.4rem;
+        }
 	}
 `
 

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -233,12 +233,14 @@ const MobileBarFilterContainer = styled.div`
     }
 
 	@media (min-width:801px) {
-		display: ${props => props.$desktopShow ? 'block' : 'none'};
+        visibility: ${props => props.$desktopShow ? 'visible' : 'hidden'};
+        top: ${props => props.$desktopShow ? '0.5rem' : '-7rem'};
         position: fixed;
         left: 1rem;
         right: 1rem;
         width: auto;
         margin: auto;
+        transition: top 0.2s ease, visibility 0.3s 0s;
 
         .filter-container {
             height: 5.4rem;


### PR DESCRIPTION
# O que foi feito
Página Programação

Essa aqui foi só uma ideia que tive, gostaria de saber se acha bom deixar ou não

Adicionado a mesma barra/nav de alterar dia que tem na versão mobile para a versão desktop.
Ela só aparecerá quando a div dos dias (a que fica logo abaixo do título "Programação") não estiver mais visível.
Com o objetivo de facilitar a navegação, ainda mais porque atualmente se o usuário estiver no final da página ele tem que subir até o topo dela para poder alterar o dia.

**Antes**

<img width="1822" height="869" alt="image" src="https://github.com/user-attachments/assets/b12ebc3d-1916-4576-a55f-c09392a13564" />


**Depois**


<img width="800" height="375" alt="2026-08-1802-56-27-ezgif com-optimize" src="https://github.com/user-attachments/assets/19b8f67a-6a49-44be-b0e1-e7bf463850dc" />

# Considerações
Se der conflito no `schedule.js`, na parte do css do StickyBackground para fazer o merge, deixe assim plss:

<img width="500" height="215" alt="image" src="https://github.com/user-attachments/assets/9c862586-391e-4bc9-bb55-e29dacc45541" />
